### PR TITLE
Additional tests for WAGTAILSHARING_HOSTNAME

### DIFF
--- a/wagtailsharing/tests/settings.py
+++ b/wagtailsharing/tests/settings.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import django
 import os
 
 
@@ -23,6 +24,31 @@ DATABASES = {
         },
     },
 }
+
+if django.VERSION >= (1, 10):
+    MIDDLEWARE = (
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+        'wagtail.wagtailcore.middleware.SiteMiddleware',
+    )
+else:
+    MIDDLEWARE_CLASSES = (
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+        'wagtail.wagtailcore.middleware.SiteMiddleware',
+    )
 
 INSTALLED_APPS = (
     'django.contrib.auth',


### PR DESCRIPTION
This PR adds a few additional tests to clarify how `WAGTAILSHARING_HOSTNAME` is supposed to work, specifically verifying that adding the sharing hostname as additional Wagtail Site is not required.

## Additions

- New tests under `wagtailsharing.tests.test_views`.

## Testing

- `tox`

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
