### PR TITLE
Add testing against Wagtail 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,25 +9,37 @@ matrix:
       python: 2.7
     - env: TOXENV=py27-dj18-wag18
       python: 2.7
+    - env: TOXENV=py27-dj18-wag19
+      python: 2.7
     - env: TOXENV=py27-dj19-wag17
       python: 2.7
     - env: TOXENV=py27-dj19-wag18
+      python: 2.7
+    - env: TOXENV=py27-dj19-wag19
       python: 2.7
     - env: TOXENV=py27-dj110-wag17
       python: 2.7
     - env: TOXENV=py27-dj110-wag18
       python: 2.7
+    - env: TOXENV=py27-dj110-wag19
+      python: 2.7
     - env: TOXENV=py35-dj18-wag17
       python: 3.5
     - env: TOXENV=py35-dj18-wag18
+      python: 3.5
+    - env: TOXENV=py35-dj18-wag19
       python: 3.5
     - env: TOXENV=py35-dj19-wag17
       python: 3.5
     - env: TOXENV=py35-dj19-wag18
       python: 3.5
+    - env: TOXENV=py35-dj19-wag19
+      python: 3.5
     - env: TOXENV=py35-dj110-wag17
       python: 3.5
     - env: TOXENV=py35-dj110-wag18
+      python: 3.5
+    - env: TOXENV=py35-dj110-wag19
       python: 3.5
 
 install:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This project has been tested for compatibility with:
 
 - Python 2.7, 3.5
 - Django 1.8, 1.9, 1.10
-- Wagtail 1.6, 1.7, 1.8
+- Wagtail 1.6, 1.7, 1.8, 1.9
 
 ## Open source licensing info
 1. [TERMS](TERMS.md)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=py{27,35}-dj{18,19,110}-wag{17,18},flake8
+envlist=py{27,35}-dj{18,19,110}-wag{17,18,19},flake8
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -21,6 +21,7 @@ deps=
     wag16: wagtail>=1.6,<1.7
     wag17: wagtail>=1.7,<1.8
     wag18: wagtail>=1.8,<1.9
+    wag19: wagtail>=1.9,<1.10
 
 [testenv:flake8]
 basepython=python3.5


### PR DESCRIPTION
This PR adds [Wagtail 1.9](http://docs.wagtail.io/en/latest/releases/1.9.html) to the list of tested versions.


## Changes

- Wagtail 1.9 added to the set of tox and Travis environments.

## Testing

- `tox`

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
