### PR TITLE
Improve sharing link text in Wagtail admin menu dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 0.3 - 2017-03-01
+
+### Changed
+- Improved sharing link text in Wagtail admin menu.
+
+
 ## 0.2 - 2017-02-22
 
 ### Changed

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -34,7 +34,7 @@ def add_sharing_link(page, page_perms, is_parent=False):
             'View sharing link',
             sharing_url,
             attrs={
-                'title': _("Share latest revision of '{}'").format(title),
+                'title': _("View shared revision of '{}'").format(title),
             },
             priority=90
         )


### PR DESCRIPTION
This PR modifies the sharing link help text in the Wagtail admin menu dropdown from 

> Share latest revision of 'title'

to

> View shared revision of 'title'

to be more consistent with the link text of "View sharing text".

It also updates the CHANGELOG in preparation for v0.3 release.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
