### PR TITLE
Use simpler method to insert preview banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## Unreleased
+
+### Changed
+- Better and simpler logic for preview banner insertion.
+
 
 ## 0.4 - 2017-03-27
 

--- a/wagtailsharing/tests/test_views.py
+++ b/wagtailsharing/tests/test_views.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.http import Http404, HttpResponse
 from django.test import RequestFactory, TestCase, override_settings
 from mock import Mock, patch
@@ -140,6 +142,16 @@ class TestServeView(TestCase):
 
     def test_banner_setting_modified_body(self):
         response = Mock(content='<body>abcde</body>')
+        response = ServeView.postprocess_response(response)
+        self.assertIn('wagtailsharing-banner', response.content)
+
+    def test_banner_setting_modified_body_not_first_tag(self):
+        response = Mock(content='<html><body>abcde</body></html>')
+        response = ServeView.postprocess_response(response)
+        self.assertIn('wagtailsharing-banner', response.content)
+
+    def test_banner_setting_modified_body_uppercase(self):
+        response = Mock(content='<BODY>abcde</BODY>')
         response = ServeView.postprocess_response(response)
         self.assertIn('wagtailsharing-banner', response.content)
 

--- a/wagtailsharing/tests/test_views.py
+++ b/wagtailsharing/tests/test_views.py
@@ -133,14 +133,22 @@ class TestServeView(TestCase):
         response = ServeView.postprocess_response(response)
         self.assertEqual(response.content, '<body>abcde</body>')
 
-    @override_settings(WAGTAILSHARING_BANNER=True)
     def test_banner_setting_no_body(self):
         response = Mock(content='abcde')
         response = ServeView.postprocess_response(response)
         self.assertEqual(response.content, 'abcde')
 
-    @override_settings(WAGTAILSHARING_BANNER=True)
     def test_banner_setting_modified_body(self):
         response = Mock(content='<body>abcde</body>')
         response = ServeView.postprocess_response(response)
         self.assertIn('wagtailsharing-banner', response.content)
+
+    def test_banner_setting_modified_body_with_attributes(self):
+        response = Mock(content='<body foo="foo" bar="bar">abcde</body>')
+        response = ServeView.postprocess_response(response)
+        self.assertIn('wagtailsharing-banner', response.content)
+
+    def test_banner_leaves_links_alone(self):
+        response = Mock(content='<body>Link <a href="#">and</a> spaces</body>')
+        response = ServeView.postprocess_response(response)
+        self.assertIn('<a href="#">and</a>', response.content)

--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -6,6 +6,7 @@ import re
 from django.conf import settings
 from django.http import Http404, HttpResponse
 from django.template import loader
+from django.utils.encoding import force_text
 from django.views.generic import View
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.views import serve as wagtail_serve
@@ -92,15 +93,19 @@ class ServeView(View):
     @staticmethod
     def add_response_banner(response):
         response.render()
-        html = str(response.content)
 
-        banner_template_name = 'wagtailsharing/banner.html'
-        banner_template = loader.get_template(banner_template_name)
-        banner_html = banner_template.render()
+        html = force_text(response.content)
+        body = re.search(r'(?i)<body.*?>', html)
 
-        body = re.match(r'<body.*?>', response.content)
         if body:
             endpos = body.end()
+
+            banner_template_name = 'wagtailsharing/banner.html'
+            banner_template = loader.get_template(banner_template_name)
+
+            banner_html = banner_template.render()
+            banner_html = force_text(banner_html)
+
             content_with_banner = html[:endpos] + banner_html + html[endpos:]
             response.content = content_with_banner
 

--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
 import inspect
+import re
 
-from bs4 import BeautifulSoup
 from django.conf import settings
 from django.http import Http404, HttpResponse
 from django.template import loader
@@ -92,17 +92,16 @@ class ServeView(View):
     @staticmethod
     def add_response_banner(response):
         response.render()
-
-        html = BeautifulSoup(response.content, 'html.parser')
+        html = str(response.content)
 
         banner_template_name = 'wagtailsharing/banner.html'
         banner_template = loader.get_template(banner_template_name)
         banner_html = banner_template.render()
 
-        banner = BeautifulSoup(banner_html, 'html.parser')
-
-        if html.body:
-            html.body.insert(0, banner)
-            response.content = html.prettify()
+        body = re.match(r'<body.*?>', response.content)
+        if body:
+            endpos = body.end()
+            content_with_banner = html[:endpos] + banner_html + html[endpos:]
+            response.content = content_with_banner
 
         return response


### PR DESCRIPTION
The use of BeautifulSoup HTML parsing and re-rendering to insert the preview banner can cause some issues with links in the page. This PR uses a simpler regex match for the body tag and string insertion to add the banner HTML to the top of the page.

It also removes a (hidden) dependence on BeautifulSoup from this package.

## Changes

- Simpler logic for banner insertion using regex vs BeautifulSoup.

## Notes

- Thanks to @Scotchester for assistance with this fix.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
