### PR TITLE
Properly limit sharing logic to HTTP GET requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ### Changed
 - Improved README formatting for PyPI.
+- Explicitly only invoke sharing logic on HTTP GET requests.
 
 
 ## 0.3 - 2017-03-01

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,8 @@ These examples obviously work best when you have some method of restricting acce
 
 Wagtail Sharing lets you create separate sharing sites for each Wagtail Site you have defined. It also supports a configurable visual banner on shared pages to remind reviewers that content may differ from your published site.
 
+This new logic only applies to ``GET`` requests. Other HTTP methods like ``POST`` defer to standard Wagtail handling.
+
 Setup
 -----
 

--- a/wagtailsharing/tests/test_views.py
+++ b/wagtailsharing/tests/test_views.py
@@ -14,8 +14,8 @@ class TestServeView(TestCase):
         self.factory = RequestFactory()
         self.default_site = Site.objects.get(is_default_site=True)
 
-    def make_request(self, path, **kwargs):
-        request = self.factory.get(path, **kwargs)
+    def make_request(self, path, method='get', **kwargs):
+        request = getattr(self.factory, method)(path, **kwargs)
         request.site = self.default_site
         return request
 
@@ -31,7 +31,21 @@ class TestServeView(TestCase):
     def test_no_sharing_site_exists_uses_wagtail_serve(self):
         request = self.make_request('/')
         with patch('wagtailsharing.views.wagtail_serve') as wagtail_serve:
-            ServeView().get(request, request.path)
+            ServeView.as_view()(request, request.path)
+            wagtail_serve.assert_called_once_with(request, request.path)
+
+    def test_no_sharing_site_exists_post_uses_wagtail_serve(self):
+        request = self.make_request('/', method='post')
+        with patch('wagtailsharing.views.wagtail_serve') as wagtail_serve:
+            ServeView.as_view()(request, request.path)
+            wagtail_serve.assert_called_once_with(request, request.path)
+
+    def test_sharing_site_post_uses_wagtail_serve(self):
+        self.create_sharing_site(hostname='hostname')
+
+        request = self.make_request('/', HTTP_HOST='hostname', method='post')
+        with patch('wagtailsharing.views.wagtail_serve') as wagtail_serve:
+            ServeView.as_view()(request, request.path)
             wagtail_serve.assert_called_once_with(request, request.path)
 
     def test_default_site_missing_page_raises_404(self):
@@ -39,14 +53,14 @@ class TestServeView(TestCase):
 
         request = self.make_request('/missing/')
         with self.assertRaises(Http404):
-            ServeView().get(request, request.path)
+            ServeView.as_view()(request, request.path)
 
     def test_sharing_site_missing_page_raises_404(self):
         self.create_sharing_site(hostname='hostname')
 
         request = self.make_request('/missing/', HTTP_HOST='hostname')
         with self.assertRaises(Http404):
-            ServeView().get(request, request.path)
+            ServeView.as_view()(request, request.path)
 
     def test_default_site_unpublished_page_raises_404(self):
         self.create_sharing_site(hostname='hostname')
@@ -54,14 +68,14 @@ class TestServeView(TestCase):
 
         request = self.make_request('/unpublished/')
         with self.assertRaises(Http404):
-            ServeView().get(request, request.path)
+            ServeView.as_view()(request, request.path)
 
     def test_sharing_site_unpublished_page_returns_200(self):
         self.create_sharing_site(hostname='hostname')
         create_draft_page(self.default_site, title='draft')
 
         request = self.make_request('/draft/', HTTP_HOST='hostname')
-        response = ServeView().get(request, request.path)
+        response = ServeView.as_view()(request, request.path)
         self.assertEqual(response.status_code, 200)
 
     def test_default_site_published_page_returns_200(self):
@@ -70,7 +84,7 @@ class TestServeView(TestCase):
         page.save_revision().publish()
 
         request = self.make_request('/published/')
-        response = ServeView().get(request, request.path)
+        response = ServeView.as_view()(request, request.path)
         self.assertEqual(response.status_code, 200)
 
     def test_sharing_site_published_page_returns_200(self):
@@ -79,7 +93,7 @@ class TestServeView(TestCase):
         page.save_revision().publish()
 
         request = self.make_request('/published/', HTTP_HOST='hostname')
-        response = ServeView().get(request, request.path)
+        response = ServeView.as_view()(request, request.path)
         self.assertEqual(response.status_code, 200)
 
     def test_default_site_draft_version_returns_published_version(self):
@@ -90,7 +104,7 @@ class TestServeView(TestCase):
         page.save_revision()
 
         request = self.make_request('/original/')
-        response = ServeView().get(request, request.path)
+        response = ServeView.as_view()(request, request.path)
         self.assert_title_matches(response, 'original')
 
     def test_sharing_site_draft_version_returns_draft_version(self):
@@ -101,7 +115,7 @@ class TestServeView(TestCase):
         page.save_revision()
 
         request = self.make_request('/original/', HTTP_HOST='hostname')
-        response = ServeView().get(request, request.path)
+        response = ServeView.as_view()(request, request.path)
         self.assert_title_matches(response, 'changed')
 
     def test_before_serve_page_hook_called(self):
@@ -112,7 +126,7 @@ class TestServeView(TestCase):
             'wagtail.wagtailcore.hooks.get_hooks'
         ) as get_hooks:
             request = self.make_request('/page/', HTTP_HOST='hostname')
-            ServeView().get(request, request.path)
+            ServeView.as_view()(request, request.path)
             get_hooks.assert_called_once_with('before_serve_page')
 
     def test_before_serve_page_hook_returns_redirect(self):
@@ -124,7 +138,7 @@ class TestServeView(TestCase):
             return_value=[Mock(return_value=HttpResponse(status=999))]
         ):
             request = self.make_request('/page/', HTTP_HOST='hostname')
-            response = ServeView().get(request, request.path)
+            response = ServeView.as_view()(request, request.path)
             self.assertEqual(response.status_code, 999)
 
     @override_settings(WAGTAILSHARING_BANNER=False)

--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -14,7 +14,10 @@ from wagtailsharing.models import SharingSite
 
 
 class ServeView(View):
-    def get(self, request, path):
+    def dispatch(self, request, path):
+        if request.method.upper() != 'GET':
+            return wagtail_serve(request, path)
+
         try:
             sharing_site = SharingSite.find_for_request(request)
         except SharingSite.DoesNotExist:


### PR DESCRIPTION
The current implementation works by using `View.get` but this breaks any non-`GET` HTTP requests, for example if a `Page` type supports some kind of `post` functionality.

This PR changes the way that `wagtailsharing.views.ServeView` works by overriding `View.dispatch` instead of `View.get` and deferring to the built-in Wagtail view functionality for any non-`GET` requests.

## Changes

- Implement sharing logic via `View.dispatch` instead of `View.get`.

## Notes

- Thanks to @higs4281 and @virginiacc for identifying this issue.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
