### PR TITLE
Update wagtail dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,43 +4,43 @@ cache: pip
 matrix:
   include:
     - env: TOXENV=flake8
-      python: 3.5
-    - env: TOXENV=py27-dj18-wag17
-      python: 2.7
+      python: 3.6
     - env: TOXENV=py27-dj18-wag18
       python: 2.7
     - env: TOXENV=py27-dj18-wag19
       python: 2.7
-    - env: TOXENV=py27-dj19-wag17
-      python: 2.7
-    - env: TOXENV=py27-dj19-wag18
-      python: 2.7
-    - env: TOXENV=py27-dj19-wag19
-      python: 2.7
-    - env: TOXENV=py27-dj110-wag17
+    - env: TOXENV=py27-dj18-wag110
       python: 2.7
     - env: TOXENV=py27-dj110-wag18
       python: 2.7
     - env: TOXENV=py27-dj110-wag19
       python: 2.7
-    - env: TOXENV=py35-dj18-wag17
-      python: 3.5
-    - env: TOXENV=py35-dj18-wag18
-      python: 3.5
-    - env: TOXENV=py35-dj18-wag19
-      python: 3.5
-    - env: TOXENV=py35-dj19-wag17
-      python: 3.5
-    - env: TOXENV=py35-dj19-wag18
-      python: 3.5
-    - env: TOXENV=py35-dj19-wag19
-      python: 3.5
-    - env: TOXENV=py35-dj110-wag17
-      python: 3.5
-    - env: TOXENV=py35-dj110-wag18
-      python: 3.5
-    - env: TOXENV=py35-dj110-wag19
-      python: 3.5
+    - env: TOXENV=py27-dj110-wag110
+      python: 2.7
+    - env: TOXENV=py27-dj111-wag18
+      python: 2.7
+    - env: TOXENV=py27-dj111-wag19
+      python: 2.7
+    - env: TOXENV=py27-dj111-wag110
+      python: 2.7
+    - env: TOXENV=py36-dj18-wag18
+      python: 3.6
+    - env: TOXENV=py36-dj18-wag19
+      python: 3.6
+    - env: TOXENV=py36-dj18-wag110
+      python: 3.6
+    - env: TOXENV=py36-dj110-wag18
+      python: 3.6
+    - env: TOXENV=py36-dj110-wag19
+      python: 3.6
+    - env: TOXENV=py36-dj110-wag110
+      python: 3.6
+    - env: TOXENV=py36-dj111-wag18
+      python: 3.6
+    - env: TOXENV=py36-dj111-wag19
+      python: 3.6
+    - env: TOXENV=py36-dj111-wag110
+      python: 3.6
 
 install:
   pip install tox coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,17 @@ matrix:
       python: 2.7
     - env: TOXENV=py27-dj18-wag110
       python: 2.7
+    - env: TOXENV=py27-dj19-wag18
+      python: 2.7
+    - env: TOXENV=py27-dj19-wag19
+      python: 2.7
+    - env: TOXENV=py27-dj19-wag110
+      python: 2.7
     - env: TOXENV=py27-dj110-wag18
       python: 2.7
     - env: TOXENV=py27-dj110-wag19
       python: 2.7
     - env: TOXENV=py27-dj110-wag110
-      python: 2.7
-    - env: TOXENV=py27-dj111-wag18
-      python: 2.7
-    - env: TOXENV=py27-dj111-wag19
-      python: 2.7
-    - env: TOXENV=py27-dj111-wag110
       python: 2.7
     - env: TOXENV=py36-dj18-wag18
       python: 3.6
@@ -29,17 +29,17 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj18-wag110
       python: 3.6
+    - env: TOXENV=py36-dj19-wag18
+      python: 3.6
+    - env: TOXENV=py36-dj19-wag19
+      python: 3.6
+    - env: TOXENV=py36-dj19-wag110
+      python: 3.6
     - env: TOXENV=py36-dj110-wag18
       python: 3.6
     - env: TOXENV=py36-dj110-wag19
       python: 3.6
     - env: TOXENV=py36-dj110-wag110
-      python: 3.6
-    - env: TOXENV=py36-dj111-wag18
-      python: 3.6
-    - env: TOXENV=py36-dj111-wag19
-      python: 3.6
-    - env: TOXENV=py36-dj111-wag110
       python: 3.6
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     'Django>=1.8,<1.11',
-    'wagtail>=1.8,<1.11',
+    'wagtail>=1.6,<1.11',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     'Django>=1.8,<1.11',
-    'wagtail>=1.6,<1.9',
+    'wagtail>=1.8,<1.11',
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=py{27,36}-dj{18,110,111}-wag{18,19,110},flake8
+envlist=py{27,36}-dj{18,19,110}-wag{18,19,110},flake8
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -16,8 +16,8 @@ basepython=
 deps=
     mock>=1.0.0
     dj18: Django>=1.8,<1.9
+    dj19: Django>=1.9,<1.10
     dj110: Django>=1.10,<1.11
-    dj111: Django>=1.11,<1.12
     wag18: wagtail>=1.8,<1.9
     wag19: wagtail>=1.9,<1.10
     wag110: wagtail>=1.10,<1.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=py{27,35}-dj{18,19,110}-wag{17,18,19},flake8
+envlist=py{27,36}-dj{18,110,111}-wag{18,19,110},flake8
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -11,19 +11,18 @@ setenv=
 
 basepython=
     py27: python2.7
-    py35: python3.5
+    py36: python3.6
 
 deps=
     mock>=1.0.0
     dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<1.10
     dj110: Django>=1.10,<1.11
-    wag16: wagtail>=1.6,<1.7
-    wag17: wagtail>=1.7,<1.8
+    dj111: Django>=1.11,<1.12
     wag18: wagtail>=1.8,<1.9
     wag19: wagtail>=1.9,<1.10
+    wag110: wagtail>=1.10,<1.11
 
 [testenv:flake8]
-basepython=python3.5
+basepython=python3.6
 deps=flake8>=2.2.0
 commands=flake8 wagtailsharing


### PR DESCRIPTION
Wagtail 1.10 is in the build matrix, and we have been successfully running the combination on cfgov-refresh.