### PR TITLE
Add testing for Django 1.11 and Wagtail 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,39 +7,17 @@ matrix:
       python: 3.6
     - env: TOXENV=py27-dj18-wag18
       python: 2.7
-    - env: TOXENV=py27-dj18-wag19
+    - env: TOXENV=py27-dj18-wag113
       python: 2.7
-    - env: TOXENV=py27-dj18-wag110
+    - env: TOXENV=py27-dj111-wag113
       python: 2.7
-    - env: TOXENV=py27-dj19-wag18
-      python: 2.7
-    - env: TOXENV=py27-dj19-wag19
-      python: 2.7
-    - env: TOXENV=py27-dj19-wag110
-      python: 2.7
-    - env: TOXENV=py27-dj110-wag18
-      python: 2.7
-    - env: TOXENV=py27-dj110-wag19
-      python: 2.7
-    - env: TOXENV=py27-dj110-wag110
-      python: 2.7
-    - env: TOXENV=py36-dj18-wag18
-      python: 3.6
-    - env: TOXENV=py36-dj18-wag19
-      python: 3.6
-    - env: TOXENV=py36-dj18-wag110
-      python: 3.6
-    - env: TOXENV=py36-dj19-wag18
-      python: 3.6
-    - env: TOXENV=py36-dj19-wag19
-      python: 3.6
-    - env: TOXENV=py36-dj19-wag110
-      python: 3.6
-    - env: TOXENV=py36-dj110-wag18
-      python: 3.6
-    - env: TOXENV=py36-dj110-wag19
-      python: 3.6
-    - env: TOXENV=py36-dj110-wag110
+    - env: TOXENV=py35-dj18-wag18
+      python: 3.5
+    - env: TOXENV=py35-dj18-wag113
+      python: 3.5
+    - env: TOXENV=py35-dj111-wag113
+      python: 3.5
+    - env: TOXENV=py36-dj111-wag113
       python: 3.6
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -98,9 +98,9 @@ Compatibility
 
 This project has been tested for compatibility with:
 
-* Python 2.7, 3.5
-* Django 1.8, 1.9, 1.10
-* Wagtail 1.6, 1.7, 1.8, 1.9
+* Python 2.7, 3.5, 3.6
+* Django 1.8-1.11
+* Wagtail 1.6-1.13
 
 Open source licensing info
 --------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 skipsdist=True
-envlist=py{27,36}-dj{18,19,110}-wag{18,19,110},flake8
+envlist=py{27,35}-dj18-wag{18,113},
+        py{27,35,36}-dj111-wag113,
+        flake8
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -11,16 +13,15 @@ setenv=
 
 basepython=
     py27: python2.7
+    py35: python3.5
     py36: python3.6
 
 deps=
     mock>=1.0.0
     dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<1.10
-    dj110: Django>=1.10,<1.11
+    dj111: Django>=1.11,<1.12
     wag18: wagtail>=1.8,<1.9
-    wag19: wagtail>=1.9,<1.10
-    wag110: wagtail>=1.10,<1.11
+    wag113: wagtail>=1.13,<1.14
 
 [testenv:flake8]
 basepython=python3.6

--- a/wagtailsharing/tests/test_views.py
+++ b/wagtailsharing/tests/test_views.py
@@ -137,11 +137,11 @@ class TestServeView(TestCase):
 
         with patch(
             'wagtail.wagtailcore.hooks.get_hooks',
-            return_value=[Mock(return_value=HttpResponse(status=999))]
+            return_value=[Mock(return_value=HttpResponse(status=123))]
         ):
             request = self.make_request('/page/', HTTP_HOST='hostname')
             response = ServeView.as_view()(request, request.path)
-            self.assertEqual(response.status_code, 999)
+            self.assertEqual(response.status_code, 123)
 
     @override_settings(WAGTAILSHARING_BANNER=False)
     def test_no_banner_setting(self):


### PR DESCRIPTION
This PR modifies the Travis CI testing matrix to add testing against Django 1.11 and Wagtail 1.13. It removes some other test combinations so that the new matrix looks like this:

- Python 2.7, Django 1.8, Wagtail 1.8
- Python 2.7, Django 1.8, Wagtail 1.13
- Python 2.7, Django 1.11, Wagtail 1.13
- Python 3.5, Django 1.11, Wagtail 1.13
- Python 3.6, Django 1.11, Wagtail 1.13

This maintains testing against the Django LTS 1.8 release as well as the Wagtail 1.8 LTS release, and adds testing against the most recent versions of both libraries.