### PR TITLE
Add additional hooks to support custom serve logic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,46 @@ Shared pages will also have a new dropdown menu option that links to this sharin
 .. image:: https://raw.githubusercontent.com/cfpb/wagtail-sharing/master/docs/images/dropdown.png
     :alt: Dropdown with sharing link
 
+Hooks
+-----
+
+ .. |before_serve_page| replace:: ``before_serve_page``
+ .. _before_serve_page: http://docs.wagtail.io/en/latest/reference/hooks.html#before-serve-page
+
+As with normal page serving, the serving of shared pages continues to respect Wagtail's built-in |before_serve_page|_ hook.
+
+This project adds these additional hooks:
+
+``before_serve_shared_page``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Called before the latest revision of the page is about to be served, just before its ``serve()`` method is called. Like ``before_serve_page`` this hook is passed the page object, the request object, and the ``args`` and ``kwargs`` that will be passed to the page's ``serve()`` method. If the callable returns an ``HttpResponse``, that response will be returned immediately to the user.
+
+This hook could be useful for limiting sharing to only certain page types or for modifying a page's contents when it is shared.
+
+.. code-block:: python
+
+  from wagtail.wagtailcore import hooks
+
+  @hooks.register('before_serve_shared_page')
+  def modify_shared_title(page, request, args, kwargs):
+      page.title += ' (Shared)'
+
+``after_serve_shared_page``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Called after the page's ``serve()`` method is called but before the response is returned to the user. This hook is passed the page object and the response object returned by ``serve()``. If the callable returns an ``HttpResponse``, that response will be returned immediately to the user.
+
+This hook could be useful for directly modifying the response content, for example by adding custom headers or altering the generated HTML. This hook is used to implement the notification banner described above.
+
+.. code-block:: python
+
+  from wagtail.wagtailcore import hooks
+
+  @hooks.register('after_serve_shared_page')
+  def add_custom_header(page, response):
+      response['Wagtail-Is-Shared'] = '1'
+
 Compatibility
 -------------
 

--- a/wagtailsharing/tests/test_views.py
+++ b/wagtailsharing/tests/test_views.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.http import Http404, HttpResponse
-from django.test import RequestFactory, TestCase, override_settings
-from mock import Mock, patch
+from django.test import RequestFactory, TestCase
+from mock import patch
 
+from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import Site
 
 from wagtailsharing.models import SharingSite
@@ -11,7 +12,19 @@ from wagtailsharing.tests.helpers import create_draft_page
 from wagtailsharing.views import ServeView
 
 
-class TestServeView(TestCase):
+def before_serve_page(page, request, args, kwargs):
+    return HttpResponse('before serve page hook')
+
+
+def before_serve_shared_page(page, request, args, kwargs):
+    page.title = 'hook changed title'
+
+
+def after_serve_shared_page(page, response):
+    response['test-hook-header'] = 'foo'
+
+
+class TestServeView(WagtailTestUtils, TestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.default_site = Site.objects.get(is_default_site=True)
@@ -124,57 +137,31 @@ class TestServeView(TestCase):
         self.create_sharing_site(hostname='hostname')
         create_draft_page(self.default_site, title='page')
 
-        with patch(
-            'wagtail.wagtailcore.hooks.get_hooks'
-        ) as get_hooks:
+        with self.register_hook('before_serve_page', before_serve_page):
             request = self.make_request('/page/', HTTP_HOST='hostname')
-            ServeView.as_view()(request, request.path)
-            get_hooks.assert_called_once_with('before_serve_page')
+            response = ServeView.as_view()(request, request.path)
+            self.assertContains(response, 'before serve page hook')
 
-    def test_before_serve_page_hook_returns_redirect(self):
+    def test_before_serve_shared_page_hook_called(self):
         self.create_sharing_site(hostname='hostname')
         create_draft_page(self.default_site, title='page')
 
-        with patch(
-            'wagtail.wagtailcore.hooks.get_hooks',
-            return_value=[Mock(return_value=HttpResponse(status=999))]
+        with self.register_hook(
+            'before_serve_shared_page',
+            before_serve_shared_page
         ):
             request = self.make_request('/page/', HTTP_HOST='hostname')
             response = ServeView.as_view()(request, request.path)
-            self.assertEqual(response.status_code, 999)
+            self.assertContains(response, 'hook changed title')
 
-    @override_settings(WAGTAILSHARING_BANNER=False)
-    def test_no_banner_setting(self):
-        response = Mock(content='<body>abcde</body>')
-        response = ServeView.postprocess_response(response)
-        self.assertEqual(response.content, '<body>abcde</body>')
+    def test_after_serve_shared_page_hook_called(self):
+        self.create_sharing_site(hostname='hostname')
+        create_draft_page(self.default_site, title='page')
 
-    def test_banner_setting_no_body(self):
-        response = Mock(content='abcde')
-        response = ServeView.postprocess_response(response)
-        self.assertEqual(response.content, 'abcde')
-
-    def test_banner_setting_modified_body(self):
-        response = Mock(content='<body>abcde</body>')
-        response = ServeView.postprocess_response(response)
-        self.assertIn('wagtailsharing-banner', response.content)
-
-    def test_banner_setting_modified_body_not_first_tag(self):
-        response = Mock(content='<html><body>abcde</body></html>')
-        response = ServeView.postprocess_response(response)
-        self.assertIn('wagtailsharing-banner', response.content)
-
-    def test_banner_setting_modified_body_uppercase(self):
-        response = Mock(content='<BODY>abcde</BODY>')
-        response = ServeView.postprocess_response(response)
-        self.assertIn('wagtailsharing-banner', response.content)
-
-    def test_banner_setting_modified_body_with_attributes(self):
-        response = Mock(content='<body foo="foo" bar="bar">abcde</body>')
-        response = ServeView.postprocess_response(response)
-        self.assertIn('wagtailsharing-banner', response.content)
-
-    def test_banner_leaves_links_alone(self):
-        response = Mock(content='<body>Link <a href="#">and</a> spaces</body>')
-        response = ServeView.postprocess_response(response)
-        self.assertIn('<a href="#">and</a>', response.content)
+        with self.register_hook(
+            'after_serve_shared_page',
+            after_serve_shared_page
+        ):
+            request = self.make_request('/page/', HTTP_HOST='hostname')
+            response = ServeView.as_view()(request, request.path)
+            self.assertEqual(response['test-hook-header'], 'foo')

--- a/wagtailsharing/tests/test_wagtail_hooks.py
+++ b/wagtailsharing/tests/test_wagtail_hooks.py
@@ -1,8 +1,12 @@
-from django.test import TestCase
+from __future__ import absolute_import, unicode_literals
+
+from django.conf import settings
+from django.http import HttpResponse
+from django.test import TestCase, override_settings
 from mock import Mock, patch
 from wagtail.tests.testapp.models import SimplePage
 
-from wagtailsharing.wagtail_hooks import add_sharing_link
+from wagtailsharing.wagtail_hooks import add_sharing_banner, add_sharing_link
 
 
 class TestAddSharingLink(TestCase):
@@ -45,3 +49,52 @@ class TestAddSharingLink(TestCase):
             self.page.get_admin_display_title = lambda: self.page.title
 
         self.check_link_makes_button()
+
+
+class TestAddSharingBanner(TestCase):
+    def setUp(self):
+        self.page = SimplePage(title='title', slug='slug', content='content')
+
+    def add_banner_to_response(self, content):
+        response = HttpResponse(content=content)
+        add_sharing_banner(self.page, response)
+        return response
+
+    @override_settings(WAGTAILSHARING_BANNER=False)
+    def test_setting_false_no_banner_added(self):
+        response = self.add_banner_to_response('<body>abcde</body>')
+        self.assertNotContains(response, 'wagtailsharing-banner')
+
+    @override_settings(WAGTAILSHARING_BANNER=True)
+    def test_setting_true_banner_is_added(self):
+        response = self.add_banner_to_response('<body>abcde</body>')
+        self.assertContains(response, 'wagtailsharing-banner')
+
+    @override_settings()
+    def test_setting_not_defined_defaults_to_true_banner_is_added(self):
+        del settings.WAGTAILSHARING_BANNER
+        response = self.add_banner_to_response('<body>abcde</body>')
+        self.assertContains(response, 'wagtailsharing-banner')
+
+    def test_no_body_in_response_content_banner_not_added(self):
+        response = self.add_banner_to_response('abcde')
+        self.assertNotContains(response, 'wagtailsharing-banner')
+
+    def test_body_not_first_tag_still_adds_banner(self):
+        content = '<html><body>abcde</body></html>'
+        response = self.add_banner_to_response(content)
+        self.assertContains(response, 'wagtailsharing-banner')
+
+    def test_body_tag_uppercase_still_adds_banner(self):
+        response = self.add_banner_to_response('<BODY>abcde</BODY>')
+        self.assertContains(response, 'wagtailsharing-banner')
+
+    def test_body_with_attributes_still_adds_banner(self):
+        content = '<body foo="foo" bar="bar">abcde</body>'
+        response = self.add_banner_to_response(content)
+        self.assertContains(response, 'wagtailsharing-banner')
+
+    def test_banner_leaves_links_alone(self):
+        content = '<body>Link <a href="#">and</a> spaces</body>'
+        response = self.add_banner_to_response(content)
+        self.assertContains(response, '<a href="#">and</a>')


### PR DESCRIPTION
This commit adds two new hooks to this project that allow for customization of the response when a shared page is served.

`before_serve_shared_page` and `after_serve_shared_page` now give users the ability to customize the serving of a shared page revision by adding hooks before and after the `Page.serve()` call. See the changes to [`README.rst`](https://github.com/chosak/wagtail-sharing/blob/custom-serve-logic/README.rst#hooks) for examples.

The sharing banner functionality has been modified to make use of these new hooks in what is hopefully a nicer approach that's more in line with Wagtail conventions.

This PR should address #18 (Support custom logic for shared pages). @tomdyson do you think this will meet the needs of your use case?

## Additions

- New `before_serve_shared_page` and `after_serve_shared_page` hooks.

## Changes

- Banner functionality pulled out into `after_serve_shared_page` hook; this simplifies the view logic and also serves as a good example of how this hook could be used.

## Testing

- See new and modified unit tests.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
