### PR TITLE
Fix minor issues with Django dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     long_description=open('README.rst').read(),
     classifiers=[
         'Framework :: Django',
+        'Framework :: Django :: 1.11',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ basepython=
 deps=
     mock>=1.0.0
     dj18: Django>=1.8,<1.9
+    dj18: djangorestframework<3.7
     dj111: Django>=1.11,<1.12
     wag18: wagtail>=1.8,<1.9
     wag113: wagtail>=1.13,<1.14


### PR DESCRIPTION
This change fixes two minor issues with Django dependencies:

First, it properly adds the "Framework :: Django :: 1.11" trove classifier to setup.py, for proper classification on PyPI.

Second, it adds a maximum version requirement for djangorestframework when testing against Django 1.8 in tox. This is necessary because DRF 3.7 removed support for Django 1.8/1.9. See https://github.com/wagtail/wagtail/pull/3912.