### PR TITLE
Enable option for relative links on shared pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Replace use of Wagtail's catch-all URL pattern:
 Sharing sites
 -------------
 
-The Wagtail admin now contains a new section under Settings called Sharing Sites that allows users to define how they would like to expose latest page revisions. 
+The Wagtail admin now contains a new section under Settings called Sharing Sites that allows users to define how they would like to expose latest page revisions.
 
 .. image:: https://raw.githubusercontent.com/cfpb/wagtail-sharing/master/docs/images/sharing-sites.png
     :width: 200px
@@ -72,6 +72,22 @@ The Wagtail admin now contains a new section under Settings called Sharing Sites
     :alt: Sharing sites
 
 No sharing sites exist by default. A sharing site must be manually created for each Wagtail Site to make its latest revisions shareable. Each sharing site is defined by a unique hostname and port number. **Important: configuring your sharing sites improperly could expose draft/private content publicly. Be careful when setting them up!**
+
+
+Middleware
+----------
+
+By default, links to other wagtail pages will go to the main Site domain. To make links stay on the sharing domain, a middleware must be added to the ``MIDDLEWARE`` configuration, after ``'wagtail.core.middleware.SiteMiddleware'``.
+
+.. code-block:: python
+
+  # in settings.py
+  MIDDLEWARE = (
+    ...
+    'wagtailsharing.middleware.SiteMiddleware',
+    ...
+  )
+
 
 Banners
 -------

--- a/wagtailsharing/middleware.py
+++ b/wagtailsharing/middleware.py
@@ -1,0 +1,21 @@
+from django.utils.deprecation import MiddlewareMixin
+
+from wagtail.wagtailcore.models import Site
+from wagtailsharing.models import SharingSite
+
+class SiteMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        """
+        Set request.site to contain the Site object responsible for handling this request,
+        according to hostname matching rules.
+        """
+
+        # request.site must exist before we can do anything
+        if not hasattr(request, 'site'):
+            raise Exception("request has no `site` attribute, make sure you define the wagtailsharing middleware after wagtail core middleware")
+
+        if request.site == None:
+            try:
+                request.site = SharingSite.find_for_request(request).site
+            except SharingSite.DoesNotExist:
+                request.site = None

--- a/wagtailsharing/tests/test_middleware.py
+++ b/wagtailsharing/tests/test_middleware.py
@@ -1,0 +1,28 @@
+from django.test import RequestFactory, TestCase, modify_settings
+from wagtail.wagtailcore.models import Site
+from wagtailsharing.middleware import SiteMiddleware
+from wagtailsharing.models import SharingSite
+
+class TestSiteMiddleware(TestCase):
+    def setUp(self):
+        self.default_site = Site.objects.get(is_default_site=True)
+        self.factory = RequestFactory()
+        self.sharing_site = SharingSite.objects.create(
+            site=self.default_site,
+            hostname='hostname'
+        )
+        self.middleware = SiteMiddleware()
+
+    def make_request(self):
+        return self.factory.get('/', HTTP_HOST=self.sharing_site.hostname)
+
+    def test_exception_thrown_when_no_site(self):
+        request = self.make_request()
+        with self.assertRaises(Exception):
+            self.middleware.process_request(request)
+
+    def test_site_is_set(self):
+        request = self.make_request()
+        request.site = None
+        self.middleware.process_request(request)
+        self.assertEqual(request.site, self.default_site)


### PR DESCRIPTION
Add a middleware to make wagtail's pageurl templatetag create relative
links. Without this middleware, hyperlinks on sharing.mysite.com will
take a user to mysite.com.

Our reviewers want to review multiple draft pages at once, so the page links should keep a user on the sharing domain.

## Additions

-

## Removals

-

## Changes

-

## Testing

Middleware tests

## Review

- @user

[Preview this PR without the whitespace changes](?w=0)

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
