### PR TITLE
Adds Django 2.0 and Wagtail 2.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Added Django check and note in README to clarify dependency on `wagtail.contrib.modeladmin` app.
 - Fixed MANIFEST.in to properly include only appropriate HTML templates.
 - Added unit test against requests without `SERVER_PORT`.
+- Added support for Django 2.0 and Wagtail 2.0.
 
 
 ## 0.6 - 2017-11-27

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Replace use of Wagtail's catch-all URL pattern:
 .. code-block:: diff
 
   # in urls.py
-  -from wagtail.wagtailcore import urls as wagtail_urls
+  -from wagtail.core import urls as wagtail_urls
   +from wagtailsharing import urls as wagtailsharing_urls
 
   ...
@@ -114,7 +114,7 @@ This hook could be useful for limiting sharing to only certain page types or for
 
 .. code-block:: python
 
-  from wagtail.wagtailcore import hooks
+  from wagtail.core import hooks
 
   @hooks.register('before_serve_shared_page')
   def modify_shared_title(page, request, args, kwargs):
@@ -129,7 +129,7 @@ This hook could be useful for directly modifying the response content, for examp
 
 .. code-block:: python
 
-  from wagtail.wagtailcore import hooks
+  from wagtail.core import hooks
 
   @hooks.register('after_serve_shared_page')
   def add_custom_header(page, response):
@@ -141,8 +141,8 @@ Compatibility
 This project has been tested for compatibility with:
 
 * Python 2.7, 3.5, 3.6
-* Django 1.8-1.11
-* Wagtail 1.6-1.13
+* Django 1.8-1.11, 2.0
+* Wagtail 1.6-1.13, 2.0
 
 Open source licensing info
 --------------------------

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    'Django>=1.8,<1.12',
-    'wagtail>=1.6,<1.14',
+    'Django>=1.8,<2.1',
+    'wagtail>=1.6,<2.1',
 ]
 
 
@@ -34,10 +34,14 @@ setup(
     long_description=open('README.rst').read(),
     classifiers=[
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
         'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
+        'Framework :: Django :: 2.0',
+        'Framework :: Wagtail',
+        'Framework :: Wagtail :: 1',
+        'Framework :: Wagtail :: 2',
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'License :: Public Domain',
         'Programming Language :: Python',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 skipsdist=True
-envlist=py{27,35}-dj18-wag{18,113},
-        py{27,35,36}-dj111-wag113,
+envlist=py{27,35,36}-dj18-wag18,
+        py{35,36}-dj111-wag113,
+        py{35,36}-dj{111,20}-wag20
         flake8
 
 [testenv]
@@ -21,8 +22,10 @@ deps=
     dj18: Django>=1.8,<1.9
     dj18: djangorestframework<3.7
     dj111: Django>=1.11,<1.12
+    dj20: Django>=2.0,<2.1
     wag18: wagtail>=1.8,<1.9
     wag113: wagtail>=1.13,<1.14
+    wag20: wagtail>=2.0,<2.1
 
 [testenv:flake8]
 basepython=python3.6

--- a/wagtailsharing/helpers.py
+++ b/wagtailsharing/helpers.py
@@ -1,4 +1,9 @@
-from wagtail.wagtailcore.models import Site
+from __future__ import absolute_import, unicode_literals
+
+try:
+    from wagtail.core.models import Site
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.models import Site
 
 from wagtailsharing.models import SharingSite
 

--- a/wagtailsharing/models.py
+++ b/wagtailsharing/models.py
@@ -2,7 +2,11 @@ from __future__ import absolute_import, unicode_literals
 
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
-from wagtail.wagtailcore.models import Site
+
+try:
+    from wagtail.core.models import Site
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.models import Site
 
 
 @python_2_unicode_compatible

--- a/wagtailsharing/tests/settings.py
+++ b/wagtailsharing/tests/settings.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import django
 import os
+import wagtail
 
 
 ALLOWED_HOSTS = ['*']
@@ -27,18 +28,68 @@ DATABASES = {
     },
 }
 
+if wagtail.VERSION >= (2, 0):
+    WAGTAIL_APPS = (
+        'wagtail.contrib.forms',
+        'wagtail.contrib.modeladmin',
+        'wagtail.contrib.settings',
+        'wagtail.tests.testapp',
+        'wagtail.admin',
+        'wagtail.core',
+        'wagtail.documents',
+        'wagtail.images',
+        'wagtail.sites',
+        'wagtail.users',
+    )
+
+    WAGTAIL_MIDDLEWARE = (
+        'wagtail.core.middleware.SiteMiddleware',
+    )
+
+    WAGTAILADMIN_RICH_TEXT_EDITORS = {
+        'default': {
+            'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea'
+        },
+        'custom': {
+            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
+        },
+    }
+else:
+    WAGTAIL_APPS = (
+        'wagtail.contrib.modeladmin',
+        'wagtail.contrib.settings',
+        'wagtail.tests.testapp',
+        'wagtail.wagtailadmin',
+        'wagtail.wagtailcore',
+        'wagtail.wagtaildocs',
+        'wagtail.wagtailforms',
+        'wagtail.wagtailimages',
+        'wagtail.wagtailsites',
+        'wagtail.wagtailusers',
+    )
+
+    WAGTAIL_MIDDLEWARE = (
+        'wagtail.wagtailcore.middleware.SiteMiddleware',
+    )
+
+    WAGTAILADMIN_RICH_TEXT_EDITORS = {
+        'default': {
+            'WIDGET': 'wagtail.wagtailadmin.rich_text.HalloRichTextArea',
+        },
+        'custom': {
+            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
+        },
+    }
+
 if django.VERSION >= (1, 10):
     MIDDLEWARE = (
         'django.middleware.common.CommonMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
-        'wagtail.wagtailcore.middleware.SiteMiddleware',
-    )
+    ) + WAGTAIL_MIDDLEWARE
 else:
     MIDDLEWARE_CLASSES = (
         'django.middleware.common.CommonMiddleware',
@@ -48,9 +99,7 @@ else:
         'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
-        'wagtail.wagtailcore.middleware.SiteMiddleware',
-    )
+    ) + WAGTAIL_MIDDLEWARE
 
 INSTALLED_APPS = (
     'django.contrib.admin',
@@ -60,18 +109,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
 
     'taggit',
-
-    'wagtail.contrib.modeladmin',
-    'wagtail.contrib.settings',
-    'wagtail.tests.testapp',
-    'wagtail.wagtailadmin',
-    'wagtail.wagtailcore',
-    'wagtail.wagtaildocs',
-    'wagtail.wagtailforms',
-    'wagtail.wagtailimages',
-    'wagtail.wagtailsites',
-    'wagtail.wagtailusers',
-
+) + WAGTAIL_APPS + (
     'wagtailsharing',
 )
 
@@ -96,12 +134,3 @@ TEMPLATES = [
 ]
 
 WAGTAIL_SITE_NAME = 'Test Site'
-
-WAGTAILADMIN_RICH_TEXT_EDITORS = {
-    'default': {
-        'WIDGET': 'wagtail.wagtailadmin.rich_text.HalloRichTextArea'
-    },
-    'custom': {
-        'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
-    },
-}

--- a/wagtailsharing/tests/test_helpers.py
+++ b/wagtailsharing/tests/test_helpers.py
@@ -1,6 +1,14 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.test import TestCase
+
+try:
+    from wagtail.core.models import Site
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.models import Site
+
 from wagtail.tests.testapp.models import SimplePage
-from wagtail.wagtailcore.models import Site
+
 
 from wagtailsharing.helpers import get_sharing_url
 from wagtailsharing.models import SharingSite

--- a/wagtailsharing/tests/test_models.py
+++ b/wagtailsharing/tests/test_models.py
@@ -1,6 +1,12 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.db import IntegrityError
 from django.test import RequestFactory, TestCase
-from wagtail.wagtailcore.models import Site
+
+try:
+    from wagtail.core.models import Site
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.models import Site
 
 from wagtailsharing.models import SharingSite
 

--- a/wagtailsharing/tests/test_urls.py
+++ b/wagtailsharing/tests/test_urls.py
@@ -1,16 +1,20 @@
-import wagtail.wagtailcore.urls
-
-import wagtailsharing.urls
-
-from django.conf.urls import url
-from django.test import TestCase
-from mock import patch
-
+from __future__ import absolute_import, unicode_literals
 
 try:
     from importlib import reload
 except ImportError:
     pass
+
+from django.conf.urls import url
+from django.test import TestCase
+from mock import patch
+
+try:
+    import wagtail.core.urls as wagtail_core_urls
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    import wagtail.wagtailcore.urls as wagtail_core_urls
+
+import wagtailsharing.urls
 
 
 class TestUrlPatterns(TestCase):
@@ -25,7 +29,7 @@ class TestUrlPatterns(TestCase):
         ]
 
         self.patcher = patch.object(
-            wagtail.wagtailcore.urls,
+            wagtail_core_urls,
             'urlpatterns',
             root_patterns
         )
@@ -37,7 +41,6 @@ class TestUrlPatterns(TestCase):
 
     def test_leaves_previous_urls_alone(self):
         self.assertEqual(self.urlpatterns[0].name, 'foo')
-        self.assertEqual(self.urlpatterns[0].regex.pattern, r'^foo/$')
 
     def test_replaces_wagtail_serve(self):
         self.assertEqual(self.urlpatterns[1].name, 'wagtail_serve')
@@ -45,4 +48,3 @@ class TestUrlPatterns(TestCase):
 
     def test_leaves_later_urls_alone(self):
         self.assertEqual(self.urlpatterns[2].name, 'bar')
-        self.assertEqual(self.urlpatterns[2].regex.pattern, r'^bar/$')

--- a/wagtailsharing/tests/test_views.py
+++ b/wagtailsharing/tests/test_views.py
@@ -4,8 +4,12 @@ from django.http import Http404, HttpResponse
 from django.test import RequestFactory, TestCase
 from mock import patch
 
+try:
+    from wagtail.core.models import Site
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.models import Site
+
 from wagtail.tests.utils import WagtailTestUtils
-from wagtail.wagtailcore.models import Site
 
 from wagtailsharing.models import SharingSite
 from wagtailsharing.tests.helpers import create_draft_page

--- a/wagtailsharing/tests/urls.py
+++ b/wagtailsharing/tests/urls.py
@@ -1,7 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import include, url
-from wagtail.wagtailadmin import urls as wagtailadmin_urls
+
+try:
+    from wagtail.admin import urls as wagtailadmin_urls
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailadmin import urls as wagtailadmin_urls
 
 from wagtailsharing import urls as wagtailsharing_urls
 

--- a/wagtailsharing/urls.py
+++ b/wagtailsharing/urls.py
@@ -1,9 +1,15 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import url
-from wagtail.wagtailcore.urls import (
-    serve_pattern, urlpatterns as wagtailcore_urlpatterns
-)
+
+try:
+    from wagtail.core.urls import (
+        serve_pattern, urlpatterns as wagtailcore_urlpatterns
+    )
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.urls import (
+        serve_pattern, urlpatterns as wagtailcore_urlpatterns
+    )
 
 from wagtailsharing.views import ServeView
 

--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -4,8 +4,13 @@ import inspect
 
 from django.http import Http404, HttpResponse
 from django.views.generic import View
-from wagtail.wagtailcore import hooks
-from wagtail.wagtailcore.views import serve as wagtail_serve
+
+try:
+    from wagtail.core import hooks
+    from wagtail.core.views import serve as wagtail_serve  # pragma: no cover
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore import hooks
+    from wagtail.wagtailcore.views import serve as wagtail_serve
 
 from wagtailsharing.models import SharingSite
 
@@ -32,8 +37,8 @@ class ServeView(View):
     def get_requested_page(site, request, path):
         """Retrieve a page from a site given a request and path.
 
-        This method uses the standard `wagtail.wagtailcore.Page.route` method
-        to retrieve a page using its path from the given site root.
+        This method uses the standard `wagtail.core.Page.route` method to
+        retrieve a page using its path from the given site root.
 
         If a requested page exists and is published, the result of `Page.route`
         can be returned directly.

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -6,9 +6,15 @@ from django.conf import settings
 from django.template import loader
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
+
+try:
+    from wagtail.admin import widgets as wagtailadmin_widgets
+    from wagtail.core import hooks  # pragma: no cover
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailadmin import widgets as wagtailadmin_widgets
+    from wagtail.wagtailcore import hooks
+
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
-from wagtail.wagtailadmin import widgets as wagtailadmin_widgets
-from wagtail.wagtailcore import hooks
 
 from wagtailsharing.helpers import get_sharing_url
 from wagtailsharing.models import SharingSite


### PR DESCRIPTION
This change adds support for Django 2.0 and Wagtail 2.0 to this package. The README has been updated to reflect the change, and example import syntax has been changed to use Wagtail 2 imports.

Throughout the code, a try/except pattern has been used to support both Wagtail 2.x and legacy 1.x import styles.

Fixes #22.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] New functions include new tests
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)