### PR TITLE
Add support for RoutablePageMixin

### DIFF
--- a/wagtailsharing/tests/helpers.py
+++ b/wagtailsharing/tests/helpers.py
@@ -1,5 +1,6 @@
 from django.utils.text import slugify
 from wagtail.tests.testapp.models import SimplePage
+from wagtail.tests.routablepage.models import RoutablePageTest
 
 
 def create_draft_page(site, title):
@@ -10,5 +11,11 @@ def create_draft_page(site, title):
         live=False
     )
 
+    site.root_page.add_child(instance=page)
+    return page
+
+
+def create_draft_routable_page(site, title):
+    page = RoutablePageTest(title=title, live=False)
     site.root_page.add_child(instance=page)
     return page

--- a/wagtailsharing/tests/settings.py
+++ b/wagtailsharing/tests/settings.py
@@ -32,7 +32,9 @@ if wagtail.VERSION >= (2, 0):
     WAGTAIL_APPS = (
         'wagtail.contrib.forms',
         'wagtail.contrib.modeladmin',
+        'wagtail.contrib.routable_page',
         'wagtail.contrib.settings',
+        'wagtail.tests.routablepage',
         'wagtail.tests.testapp',
         'wagtail.admin',
         'wagtail.core',
@@ -57,7 +59,9 @@ if wagtail.VERSION >= (2, 0):
 else:
     WAGTAIL_APPS = (
         'wagtail.contrib.modeladmin',
+        'wagtail.contrib.wagtailroutablepage',
         'wagtail.contrib.settings',
+        'wagtail.tests.routablepage',
         'wagtail.tests.testapp',
         'wagtail.wagtailadmin',
         'wagtail.wagtailcore',

--- a/wagtailsharing/tests/test_views.py
+++ b/wagtailsharing/tests/test_views.py
@@ -12,7 +12,9 @@ except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
 from wagtail.tests.utils import WagtailTestUtils
 
 from wagtailsharing.models import SharingSite
-from wagtailsharing.tests.helpers import create_draft_page
+from wagtailsharing.tests.helpers import (
+    create_draft_page, create_draft_routable_page
+)
 from wagtailsharing.views import ServeView
 
 
@@ -200,3 +202,22 @@ class TestServeView(WagtailTestUtils, TestCase):
             request = self.make_request('/page/', HTTP_HOST='hostname')
             response = ServeView.as_view()(request, request.path)
             self.assertContains(response, 'returned by hook')
+
+    def test_routable_page_index_route(self):
+        self.create_sharing_site(hostname='hostname')
+        create_draft_routable_page(self.default_site, title='routable')
+
+        request = self.make_request('/routable/', HTTP_HOST='hostname')
+        response = ServeView.as_view()(request, request.path)
+        self.assertEqual(response.status_code, 200)
+
+    def test_routable_page_sub_route(self):
+        self.create_sharing_site(hostname='hostname')
+        create_draft_routable_page(self.default_site, title='routable')
+
+        request = self.make_request(
+            '/routable/archive/year/2000/',
+            HTTP_HOST='hostname'
+        )
+        response = ServeView.as_view()(request, request.path)
+        self.assertContains(response, 'ARCHIVE BY YEAR: 2000')

--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -7,8 +7,8 @@ from django.views.generic import View
 
 try:
     from wagtail.contrib.routable_page.models import RoutablePageMixin
-    from wagtail.core import hooks
-    from wagtail.core.url_routing import RouteResult
+    from wagtail.core import hooks  # pragma: no cover
+    from wagtail.core.url_routing import RouteResult  # pragma: no cover
     from wagtail.core.views import serve as wagtail_serve  # pragma: no cover
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin

--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -6,10 +6,14 @@ from django.http import Http404, HttpResponse
 from django.views.generic import View
 
 try:
+    from wagtail.contrib.routable_page.models import RoutablePageMixin
     from wagtail.core import hooks
+    from wagtail.core.url_routing import RouteResult
     from wagtail.core.views import serve as wagtail_serve  # pragma: no cover
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin
     from wagtail.wagtailcore import hooks
+    from wagtail.wagtailcore.url_routing import RouteResult
     from wagtail.wagtailcore.views import serve as wagtail_serve
 
 from wagtailsharing.models import SharingSite
@@ -25,16 +29,12 @@ class ServeView(View):
         except SharingSite.DoesNotExist:
             return wagtail_serve(request, path)
 
-        page, args, kwargs = self.get_requested_page(
-            sharing_site.site,
-            request,
-            path
-        )
+        page, args, kwargs = self.route(sharing_site.site, request, path)
 
-        return self.serve_latest_revision(page, request, args, kwargs)
+        return self.serve(page, request, args, kwargs)
 
     @staticmethod
-    def get_requested_page(site, request, path):
+    def route(site, request, path):
         """Retrieve a page from a site given a request and path.
 
         This method uses the standard `wagtail.core.Page.route` method to
@@ -63,13 +63,22 @@ class ServeView(View):
             page = stack_frame.f_locals['self']
             path_components = stack_frame.f_locals['path_components']
 
-            if path_components:
+            if isinstance(page, RoutablePageMixin):
+                # This mimics the way that RoutablePageMixin uses the
+                # RouteResult to store the page route view to call.
+                path = '/'
+                if path_components:
+                    path += '/'.join(path_components) + '/'
+
+                view, args, kwargs = page.resolve_subpage(path)
+                return RouteResult(page, args=(view, args, kwargs))
+            elif path_components:
                 raise
 
-            return page, [], {}
+            return RouteResult(page)
 
-    @classmethod
-    def serve_latest_revision(cls, page, request, args, kwargs):
+    @staticmethod
+    def serve(page, request, args, kwargs):
         # Call the before_serve_page hook.
         for fn in hooks.get_hooks('before_serve_page'):
             result = fn(page, request, args, kwargs)


### PR DESCRIPTION
This change adds logic to support pages that inherit from Wagtail's RoutablePageMixin, as documented [here](https://docs.wagtail.io/en/latest/reference/contrib/routablepage.html).

Currently, subpages of routable pages cannot be previewed if the page has never been published. This corrects that, allowing pages that inherit from `RoutablePageMixin` to be previewed on sharing sites.

See the added tests for examples of how this can be used.

Fixes #27.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [X] Visually tested in supported browsers and devices
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
