### PR TITLE
Support Wagtail 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,18 @@ matrix:
   include:
     - env: TOXENV=flake8
       python: 3.6
+    - env: TOXENV=py37-dj111-wag113
+      python: 3.7
+    - env: TOXENV=py37-dj20-wag23
+      python: 3.7
+    - env: TOXENV=py37-dj20-wag27
+      python: 3.7
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
     - env: TOXENV=py36-dj20-wag23
       python: 3.6
     - env: TOXENV=py36-dj20-wag27
       python: 3.6
-    - env: TOXENV=py35-dj111-wag113
-      python: 3.5
-    - env: TOXENV=py35-dj20-wag23
-      python: 3.5
-    - env: TOXENV=py35-dj20-wag27
-      python: 3.5
 
 install:
   pip install tox coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,16 @@ matrix:
   include:
     - env: TOXENV=flake8
       python: 3.6
-    - env: TOXENV=py38-dj111-wag113
-      python: 3.8
-    - env: TOXENV=py38-dj20-wag23
-      python: 3.8
-    - env: TOXENV=py38-dj20-wag27
-      python: 3.8
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
     - env: TOXENV=py36-dj20-wag23
       python: 3.6
-    - env: TOXENV=py36-dj20-wag27
+    - env: TOXENV=py36-dj20-wag28
       python: 3.6
+    - env: TOXENV=py38-dj111-wag113
+      python: 3.8
+    - env: TOXENV=py38-dj20-wag28
+      python: 3.8
 
 install:
   pip install tox coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
+    - env: TOXENV=py36-dj111-wag23
+      python: 3.6
     - env: TOXENV=py36-dj20-wag23
       python: 3.6
     - env: TOXENV=py36-dj20-wag28
       python: 3.6
-    - env: TOXENV=py38-dj111-wag113
+    - env: TOXENV=py38-dj20-wag23
       python: 3.8
     - env: TOXENV=py38-dj20-wag28
       python: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,18 @@ matrix:
   include:
     - env: TOXENV=flake8
       python: 3.6
-    - env: TOXENV=py27-dj18-wag18
-      python: 2.7
-    - env: TOXENV=py27-dj18-wag113
-      python: 2.7
-    - env: TOXENV=py27-dj111-wag113
-      python: 2.7
-    - env: TOXENV=py35-dj18-wag18
-      python: 3.5
-    - env: TOXENV=py35-dj18-wag113
-      python: 3.5
-    - env: TOXENV=py35-dj111-wag113
-      python: 3.5
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
+    - env: TOXENV=py36-dj20-wag23
+      python: 3.6
+    - env: TOXENV=py36-dj20-wag27
+      python: 3.6
+    - env: TOXENV=py35-dj111-wag113
+      python: 3.5
+    - env: TOXENV=py35-dj20-wag23
+      python: 3.5
+    - env: TOXENV=py35-dj20-wag27
+      python: 3.5
 
 install:
   pip install tox coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ matrix:
   include:
     - env: TOXENV=flake8
       python: 3.6
-    - env: TOXENV=py37-dj111-wag113
-      python: 3.7
-    - env: TOXENV=py37-dj20-wag23
-      python: 3.7
-    - env: TOXENV=py37-dj20-wag27
-      python: 3.7
+    - env: TOXENV=py38-dj111-wag113
+      python: 3.8
+    - env: TOXENV=py38-dj20-wag23
+      python: 3.8
+    - env: TOXENV=py38-dj20-wag27
+      python: 3.8
     - env: TOXENV=py36-dj111-wag113
       python: 3.6
     - env: TOXENV=py36-dj20-wag23

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj20-wag23
       python: 3.6
-    - env: TOXENV=py36-dj20-wag28
+    - env: TOXENV=py36-dj22-wag28
       python: 3.6
     - env: TOXENV=py38-dj20-wag23
       python: 3.8
-    - env: TOXENV=py38-dj20-wag28
+    - env: TOXENV=py38-dj22-wag28
       python: 3.8
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -166,8 +166,8 @@ This project has been tested for compatibility with:
 * Django 1.11, 2.0, 2.2
 * Wagtail 1.13, 2.3, 2.8
 
-It should be compatible at all intermediate versions, as well.
-If you find that it is not, please [file an issue](issues/new).
+It should be compatible with all intermediate versions, as well.
+If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-sharing/issues/new>`_
 
 Open source licensing info
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ This project has been tested for compatibility with:
 * Wagtail 1.13, 2.3, 2.8
 
 It should be compatible with all intermediate versions, as well.
-If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-sharing/issues/new>`_
+If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-sharing/issues/new>`_.
 
 Open source licensing info
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -162,9 +162,12 @@ Compatibility
 
 This project has been tested for compatibility with:
 
-* Python 3
-* Django 1.11, 2.0-2.2
-* Wagtail 1.13, 2.3-2.8
+* Python 3.6, 3.8
+* Django 1.11, 2.0, 2.2
+* Wagtail 1.13, 2.3, 2.8
+
+It should be compatible at all intermediate versions, as well.
+If you find that it is not, please [file an issue](issues/new).
 
 Open source licensing info
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -162,9 +162,9 @@ Compatibility
 
 This project has been tested for compatibility with:
 
-* Python 2.7, 3.5, 3.6
-* Django 1.8-1.11, 2.0
-* Wagtail 1.6-1.13, 2.0
+* Python 3.5, 3.6
+* Django 1.8-1.11, 2.2
+* Wagtail 1.6-1.13, 2.3, 2.7
 
 Open source licensing info
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ Compatibility
 
 This project has been tested for compatibility with:
 
-* Python 3.5, 3.6
+* Python 3.6, 3.7, 3.8
 * Django 1.11, 2.0, 2.2
 * Wagtail 1.13, 2.3, 2.7
 

--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ Compatibility
 
 This project has been tested for compatibility with:
 
-* Python 3.5, 3.6
+* Python 3.6
 * Django 1.8-1.11, 2.2
 * Wagtail 1.6-1.13, 2.3, 2.7
 

--- a/README.rst
+++ b/README.rst
@@ -162,9 +162,9 @@ Compatibility
 
 This project has been tested for compatibility with:
 
-* Python 3.6, 3.8
-* Django 1.11, 2.0, 2.2
-* Wagtail 1.13, 2.3, 2.8
+* Python 3
+* Django 1.11, 2.0-2.2
+* Wagtail 1.13, 2.3-2.8
 
 Open source licensing info
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,7 @@ This project has been tested for compatibility with:
 
 * Python 3.6, 3.8
 * Django 1.11, 2.0, 2.2
-* Wagtail 1.13, 2.3, 2.7
+* Wagtail 1.13, 2.3, 2.8
 
 Open source licensing info
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ Compatibility
 
 This project has been tested for compatibility with:
 
-* Python 3.6, 3.7, 3.8
+* Python 3.6, 3.8
 * Django 1.11, 2.0, 2.2
 * Wagtail 1.13, 2.3, 2.7
 

--- a/README.rst
+++ b/README.rst
@@ -162,9 +162,9 @@ Compatibility
 
 This project has been tested for compatibility with:
 
-* Python 3.6
-* Django 1.8-1.11, 2.2
-* Wagtail 1.6-1.13, 2.3, 2.7
+* Python 3.5, 3.6
+* Django 1.11, 2.0, 2.2
+* Wagtail 1.13, 2.3, 2.7
 
 Open source licensing info
 --------------------------

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 1',
@@ -44,7 +45,5 @@ setup(
         'License :: Public Domain',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.8',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ setup(
         'License :: Public Domain',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     'Django>=1.11,<2.3',
-    'wagtail>=1.6,<2.8',
+    'wagtail>=1.6,<2.9',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    'Django>=1.8,<2.3',
+    'Django>=1.11,<2.3',
     'wagtail>=1.6,<2.8',
 ]
 
@@ -34,10 +34,8 @@ setup(
     long_description=open('README.rst').read(),
     classifiers=[
         'Framework :: Django',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.2',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 1',
@@ -46,6 +44,7 @@ setup(
         'License :: Public Domain',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    'Django>=1.8,<2.1',
-    'wagtail>=1.6,<2.1',
+    'Django>=1.8,<2.3',
+    'wagtail>=1.6,<2.8',
 ]
 
 
@@ -38,15 +38,13 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
-        'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.2',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 1',
         'Framework :: Wagtail :: 2',
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'License :: Public Domain',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps=
     mock>=1.0.0
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
-envlist=py36-dj111-wag113,
-        py36-dj20-wag{23,27}
+envlist=py{36}-dj{111}-wag{113},
+        py{36,37}-dj{20}-wag{23,27}
         flake8
 
 [testenv]
@@ -12,13 +12,15 @@ setenv=
     DJANGO_SETTINGS_MODULE=wagtailsharing.tests.settings
 
 basepython=
-    py35: python3.5
     py36: python3.6
+    py37: python3.7
+    py38: python3.8
 
 deps=
     mock>=1.0.0
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 skipsdist=True
-envlist=py{36}-dj18-wag18,
-        py{36}-dj111-wag113,
-        py{36}-dj{111,22}-wag{23,27}
+envlist=py36-dj111-wag113,
+        py36-dj20-wag{23,27}
         flake8
 
 [testenv]
@@ -13,15 +12,14 @@ setenv=
     DJANGO_SETTINGS_MODULE=wagtailsharing.tests.settings
 
 basepython=
+    py35: python3.5
     py36: python3.6
 
 deps=
     mock>=1.0.0
-    dj18: Django>=1.8,<1.9
-    dj18: djangorestframework<3.7
     dj111: Django>=1.11,<1.12
+    dj20: Django>=2.0,<2.1
     dj22: Django>=2.2,<2.3
-    wag18: wagtail>=1.8,<1.9
     wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4
     wag27: wagtail>=2.7,<2.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist=True
-envlist=py{35,36}-dj18-wag18,
-        py{35,36}-dj111-wag113,
-        py{35,36}-dj{111,22}-wag{23,27}
+envlist=py{36}-dj18-wag18,
+        py{36}-dj111-wag113,
+        py{36}-dj{111,22}-wag{23,27}
         flake8
 
 [testenv]
@@ -13,7 +13,6 @@ setenv=
     DJANGO_SETTINGS_MODULE=wagtailsharing.tests.settings
 
 basepython=
-    py35: python3.5
     py36: python3.6
 
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 skipsdist=True
-envlist=py{36}-dj111-wag{113,23},
-        py{36}-dj20-wag23,
-        py{36,38}-dj20-wag28,
-        flake8
+envlist=
+    flake8,
+    py{36}-dj{111}-wag{113},
+    py{36}-dj{111,20,22}-wag{23},
+    py{36,38}-dj{22}-wag{28}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ deps=
     mock>=1.0.0
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 envlist=py{36}-dj{111}-wag{113},
-        py{36,38}-dj{20}-wag{23,27}
+        py{36,38}-dj{20}-wag{23,27},
         flake8
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 envlist=py{36}-dj{111}-wag{113},
-        py{36,37}-dj{20}-wag{23,27}
+        py{36,38}-dj{20}-wag{23,27}
         flake8
 
 [testenv]
@@ -13,7 +13,6 @@ setenv=
 
 basepython=
     py36: python3.6
-    py37: python3.7
     py38: python3.8
 
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 skipsdist=True
-envlist=py{36}-dj{111}-wag{113},
-        py{36,38}-dj{20}-wag{23,27},
+envlist=py{36}-dj111-wag113,
+        py{36}-dj20-wag23,
+        py{36,38}-dj20-wag28,
         flake8
 
 [testenv]
@@ -19,11 +20,10 @@ deps=
     mock>=1.0.0
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
     wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4
-    wag27: wagtail>=2.7,<2.8
+    wag28: wagtail>=2.8,<2.9
 
 [testenv:flake8]
 basepython=python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=py{36}-dj111-wag113,
+envlist=py{36}-dj111-wag{113,23},
         py{36}-dj20-wag23,
         py{36,38}-dj20-wag28,
         flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist=True
-envlist=py{27,35,36}-dj18-wag18,
+envlist=py{35,36}-dj18-wag18,
         py{35,36}-dj111-wag113,
-        py{35,36}-dj{111,20}-wag20
+        py{35,36}-dj{111,22}-wag{23,27}
         flake8
 
 [testenv]
@@ -13,7 +13,6 @@ setenv=
     DJANGO_SETTINGS_MODULE=wagtailsharing.tests.settings
 
 basepython=
-    py27: python2.7
     py35: python3.5
     py36: python3.6
 
@@ -22,10 +21,11 @@ deps=
     dj18: Django>=1.8,<1.9
     dj18: djangorestframework<3.7
     dj111: Django>=1.11,<1.12
-    dj20: Django>=2.0,<2.1
+    dj22: Django>=2.2,<2.3
     wag18: wagtail>=1.8,<1.9
     wag113: wagtail>=1.13,<1.14
-    wag20: wagtail>=2.0,<2.1
+    wag23: wagtail>=2.3,<2.4
+    wag27: wagtail>=2.7,<2.8
 
 [testenv:flake8]
 basepython=python3.6

--- a/wagtailsharing/tests/settings.py
+++ b/wagtailsharing/tests/settings.py
@@ -109,9 +109,9 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.messages',
     'django.contrib.sessions',
     'django.contrib.staticfiles',
-
     'taggit',
 ) + WAGTAIL_APPS + (
     'wagtailsharing',


### PR DESCRIPTION
Support production version of Python 3.6 and latest version of Python 3.8
Support production version of Wagtail 1.11 and latest version of Wagtail 2.8

Remove Python 2.7 and 3.5, add Python 3.8:
* README.rst
* setup.py
* tox.ini
* travis.yml
Add support for Wagtail 2.8 to `tox.ini`, `setup.py`, and `travis.yml`

Testing
$ tox
```
...
  flake8: commands succeeded
  py36-dj111-wag113: commands succeeded
  py36-dj111-wag23: commands succeeded
  py36-dj20-wag23: commands succeeded
  py36-dj22-wag23: commands succeeded
  py36-dj22-wag28: commands succeeded
  py38-dj22-wag28: commands succeeded
  congratulations :)
```