### PR TITLE
Remove Wagtail 1.13 support, add Django 2.2 import support, and add Black for autoformatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ cache: pip
 
 matrix:
   include:
-    - env: TOXENV=flake8
-      python: 3.6
-    - env: TOXENV=py36-dj111-wag113
+    - env: TOXENV=lint
       python: 3.6
     - env: TOXENV=py36-dj111-wag23
       python: 3.6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,23 @@ tests that validate implemented features and the presence or lack of defects.
 Additionally, the code should follow any stylistic and architectural guidelines
 prescribed by the project. In the absence of such guidelines, mimic the styles
 and patterns in the existing code-base.
+
+
+## Style
+
+This project uses [`black`](https://github.com/psf/black) to format code,
+[`isort`](https://github.com/timothycrosley/isort) to format imports,
+and [`flake8`](https://gitlab.com/pycqa/flake8).
+
+You can format code and imports by calling:
+
+```
+black wagtailsharing
+isort --recursive wagtailsharing
+```
+
+And you can check for style, import order, and other linting by using:
+
+```
+tox -e lint
+```

--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,7 @@ This project has been tested for compatibility with:
 
 * Python 3.6, 3.8
 * Django 1.11, 2.0, 2.2
-* Wagtail 1.13, 2.3, 2.8
+* Wagtail 2.3, 2.8
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-sharing/issues/new>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.black]
+line-length = 79
+target-version = ['py36', 'py38']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.eggs
+    | \.git
+    | \.tox
+    | \*.egg-info
+    | _build
+    | build
+    | dist
+    | migrations
+    | site
+    | \*.json
+    | \*.csv
+  )/
+)
+'''
+
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,
-    extras_require={"testing": testing_extras,},
+    extras_require={"testing": testing_extras},
     description=short_description,
     long_description=open("README.rst").read(),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "Django>=1.11,<2.3",
-    "wagtail>=1.6,<2.9",
+    "wagtail>=2.3,<2.9",
 ]
 
 
@@ -37,7 +37,6 @@ setup(
         "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
         "Framework :: Wagtail",
-        "Framework :: Wagtail :: 1",
         "Framework :: Wagtail :: 2",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
         "License :: Public Domain",

--- a/setup.py
+++ b/setup.py
@@ -2,48 +2,46 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    'Django>=1.11,<2.3',
-    'wagtail>=1.6,<2.9',
+    "Django>=1.11,<2.3",
+    "wagtail>=1.6,<2.9",
 ]
 
 
 testing_extras = [
-    'coverage>=3.7.0',
-    'flake8>=2.2.0',
-    'mock>=1.0.0',
+    "coverage>=3.7.0",
+    "flake8>=2.2.0",
+    "mock>=1.0.0",
 ]
 
 
-short_description = 'Easier sharing of Wagtail drafts'
+short_description = "Easier sharing of Wagtail drafts"
 
 
 setup(
-    name='wagtail-sharing',
-    url='https://github.com/cfpb/wagtail-sharing',
-    author='CFPB',
-    author_email='tech@cfpb.gov',
-    license='CCO',
-    version='1.0',
+    name="wagtail-sharing",
+    url="https://github.com/cfpb/wagtail-sharing",
+    author="CFPB",
+    author_email="tech@cfpb.gov",
+    license="CCO",
+    version="1.0",
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,
-    extras_require={
-        'testing': testing_extras,
-    },
+    extras_require={"testing": testing_extras,},
     description=short_description,
-    long_description=open('README.rst').read(),
+    long_description=open("README.rst").read(),
     classifiers=[
-        'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
-        'Framework :: Django :: 2.2',
-        'Framework :: Wagtail',
-        'Framework :: Wagtail :: 1',
-        'Framework :: Wagtail :: 2',
-        'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
-        'License :: Public Domain',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-    ]
+        "Framework :: Django",
+        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.0",
+        "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
+        "Framework :: Wagtail",
+        "Framework :: Wagtail :: 1",
+        "Framework :: Wagtail :: 2",
+        "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+        "License :: Public Domain",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 envlist=
-    flake8,
+    lint,
     py{36}-dj{111}-wag{113},
     py{36}-dj{111,20,22}-wag{23},
     py{36,38}-dj{22}-wag{28}
@@ -26,7 +26,36 @@ deps=
     wag23: wagtail>=2.3,<2.4
     wag28: wagtail>=2.8,<2.9
 
-[testenv:flake8]
+[testenv:lint]
+recreate=False
 basepython=python3.6
-deps=flake8>=2.2.0
-commands=flake8 wagtailsharing
+deps=
+    black
+    flake8
+    isort
+commands=
+    black --check wagtailsharing setup.py
+    flake8 wagtailsharing
+    isort --check-only --diff --recursive wagtailsharing
+
+[flake8]
+ignore=E731,W503,W504
+exclude=
+    .git,
+    .tox,
+    __pycache__,
+    */migrations/*.py,
+    .eggs/*,
+
+[isort]
+combine_as_imports=1
+lines_after_imports=2
+include_trailing_comma=1
+multi_line_output=3
+skip=.tox,migrations
+not_skip=__init__.py
+use_parentheses=1
+known_django=django
+known_future_library=future
+default_section=THIRDPARTY
+sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-dj{111}-wag{113},
     py{36}-dj{111,20,22}-wag{23},
     py{36,38}-dj{22}-wag{28}
 
@@ -22,7 +21,6 @@ deps=
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
     dj22: Django>=2.2,<2.3
-    wag113: wagtail>=1.13,<1.14
     wag23: wagtail>=2.3,<2.4
     wag28: wagtail>=2.8,<2.9
 

--- a/wagtailsharing/__init__.py
+++ b/wagtailsharing/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'wagtailsharing.apps.WagtailSharingAppConfig'
+default_app_config = "wagtailsharing.apps.WagtailSharingAppConfig"

--- a/wagtailsharing/apps.py
+++ b/wagtailsharing/apps.py
@@ -5,6 +5,6 @@ from . import checks  # noqa F401
 
 
 class WagtailSharingAppConfig(AppConfig):
-    name = 'wagtailsharing'
-    label = 'wagtailsharing'
+    name = "wagtailsharing"
+    label = "wagtailsharing"
     verbose_name = _("Wagtail Sharing")

--- a/wagtailsharing/checks.py
+++ b/wagtailsharing/checks.py
@@ -6,17 +6,17 @@ from django.core.checks import Error, register
 def modeladmin_installed_check(app_configs, **kwargs):
     errors = []
 
-    MODELADMIN_APP = 'wagtail.contrib.modeladmin'
+    MODELADMIN_APP = "wagtail.contrib.modeladmin"
     if not apps.is_installed(MODELADMIN_APP):
-        error_hint = (
-            "Is '{}' in settings.INSTALLED_APPS?".format(MODELADMIN_APP)
+        error_hint = "Is '{}' in settings.INSTALLED_APPS?".format(
+            MODELADMIN_APP
         )
 
         errors.append(
             Error(
                 "wagtail-sharing requires the Wagtail ModelAdmin app.",
                 hint=error_hint,
-                id='wagtailsharing.E001'
+                id="wagtailsharing.E001",
             )
         )
 

--- a/wagtailsharing/helpers.py
+++ b/wagtailsharing/helpers.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from wagtail.core.models import Site
 from wagtailsharing.models import SharingSite
 

--- a/wagtailsharing/helpers.py
+++ b/wagtailsharing/helpers.py
@@ -1,12 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
+from wagtail.core.models import Site
 from wagtailsharing.models import SharingSite
-
-
-try:
-    from wagtail.core.models import Site
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Site
 
 
 def get_sharing_url(page):

--- a/wagtailsharing/helpers.py
+++ b/wagtailsharing/helpers.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
+from wagtailsharing.models import SharingSite
+
+
 try:
     from wagtail.core.models import Site
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.models import Site
-
-from wagtailsharing.models import SharingSite
 
 
 def get_sharing_url(page):

--- a/wagtailsharing/migrations/0001_initial.py
+++ b/wagtailsharing/migrations/0001_initial.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 import django.db.models.deletion
 

--- a/wagtailsharing/models.py
+++ b/wagtailsharing/models.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 

--- a/wagtailsharing/models.py
+++ b/wagtailsharing/models.py
@@ -3,11 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
-
-try:
-    from wagtail.core.models import Site
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Site
+from wagtail.core.models import Site
 
 
 @python_2_unicode_compatible

--- a/wagtailsharing/models.py
+++ b/wagtailsharing/models.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
+
 try:
     from wagtail.core.models import Site
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
@@ -11,19 +12,17 @@ except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
 
 @python_2_unicode_compatible
 class SharingSite(models.Model):
-    site = models.OneToOneField(Site, on_delete=models.CASCADE,
-                                related_name='sharing_site')
+    site = models.OneToOneField(
+        Site, on_delete=models.CASCADE, related_name="sharing_site"
+    )
     hostname = models.CharField(max_length=255, db_index=True)
     port = models.IntegerField(default=80)
 
     class Meta:
-        unique_together = ('hostname', 'port')
+        unique_together = ("hostname", "port")
 
     def __str__(self):
-        return(
-            self.hostname +
-            ('' if self.port == 80 else (':%d' % self.port))
-        )
+        return self.hostname + ("" if self.port == 80 else (":%d" % self.port))
 
     @classmethod
     def find_for_request(cls, request):
@@ -34,22 +33,22 @@ class SharingSite(models.Model):
         Uses request hostname and port to find matching sharing site.
         """
         try:
-            hostname = request.get_host().split(':')[0]
+            hostname = request.get_host().split(":")[0]
         except KeyError:
             hostname = None
 
         try:
             port = request.get_port()
         except (AttributeError, KeyError):
-            port = request.META.get('SERVER_PORT')
+            port = request.META.get("SERVER_PORT")
 
         return cls.objects.get(hostname=hostname, port=port)
 
     @property
     def root_url(self):
         if self.port == 80:
-            return 'http://{}'.format(self.hostname)
+            return "http://{}".format(self.hostname)
         elif self.port == 443:
-            return 'https://{}'.format(self.hostname)
+            return "https://{}".format(self.hostname)
         else:
-            return 'http://{}:{:d}'.format(self.hostname, self.port)
+            return "http://{}:{:d}".format(self.hostname, self.port)

--- a/wagtailsharing/tests/helpers.py
+++ b/wagtailsharing/tests/helpers.py
@@ -1,14 +1,12 @@
 from django.utils.text import slugify
-from wagtail.tests.testapp.models import SimplePage
+
 from wagtail.tests.routablepage.models import RoutablePageTest
+from wagtail.tests.testapp.models import SimplePage
 
 
 def create_draft_page(site, title):
     page = SimplePage(
-        title=title,
-        slug=slugify(title),
-        content='content',
-        live=False
+        title=title, slug=slugify(title), content="content", live=False
     )
 
     site.root_page.add_child(instance=page)

--- a/wagtailsharing/tests/settings.py
+++ b/wagtailsharing/tests/settings.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 
 import django

--- a/wagtailsharing/tests/settings.py
+++ b/wagtailsharing/tests/settings.py
@@ -4,8 +4,6 @@ import os
 
 import django
 
-import wagtail
-
 
 ALLOWED_HOSTS = ["*"]
 
@@ -26,56 +24,29 @@ DATABASES = {
     },
 }
 
-if wagtail.VERSION >= (2, 0):
-    WAGTAIL_APPS = (
-        "wagtail.contrib.forms",
-        "wagtail.contrib.modeladmin",
-        "wagtail.contrib.routable_page",
-        "wagtail.contrib.settings",
-        "wagtail.tests.routablepage",
-        "wagtail.tests.testapp",
-        "wagtail.admin",
-        "wagtail.core",
-        "wagtail.documents",
-        "wagtail.images",
-        "wagtail.sites",
-        "wagtail.users",
-    )
 
-    WAGTAIL_MIDDLEWARE = ("wagtail.core.middleware.SiteMiddleware",)
+WAGTAIL_APPS = (
+    "wagtail.contrib.forms",
+    "wagtail.contrib.modeladmin",
+    "wagtail.contrib.routable_page",
+    "wagtail.contrib.settings",
+    "wagtail.tests.routablepage",
+    "wagtail.tests.testapp",
+    "wagtail.admin",
+    "wagtail.core",
+    "wagtail.documents",
+    "wagtail.images",
+    "wagtail.sites",
+    "wagtail.users",
+)
 
-    WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
-        "custom": {
-            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
-        },
-    }
-else:
-    WAGTAIL_APPS = (
-        "wagtail.contrib.modeladmin",
-        "wagtail.contrib.wagtailroutablepage",
-        "wagtail.contrib.settings",
-        "wagtail.tests.routablepage",
-        "wagtail.tests.testapp",
-        "wagtail.wagtailadmin",
-        "wagtail.wagtailcore",
-        "wagtail.wagtaildocs",
-        "wagtail.wagtailforms",
-        "wagtail.wagtailimages",
-        "wagtail.wagtailsites",
-        "wagtail.wagtailusers",
-    )
+WAGTAIL_MIDDLEWARE = ("wagtail.core.middleware.SiteMiddleware",)
 
-    WAGTAIL_MIDDLEWARE = ("wagtail.wagtailcore.middleware.SiteMiddleware",)
+WAGTAILADMIN_RICH_TEXT_EDITORS = {
+    "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
+    "custom": {"WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"},
+}
 
-    WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        "default": {
-            "WIDGET": "wagtail.wagtailadmin.rich_text.HalloRichTextArea",
-        },
-        "custom": {
-            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
-        },
-    }
 
 if django.VERSION >= (1, 10):
     MIDDLEWARE = (

--- a/wagtailsharing/tests/settings.py
+++ b/wagtailsharing/tests/settings.py
@@ -1,140 +1,134 @@
 from __future__ import absolute_import, unicode_literals
 
-import django
 import os
+
+import django
+
 import wagtail
 
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
-SECRET_KEY = 'not needed'
+SECRET_KEY = "not needed"
 
-ROOT_URLCONF = 'wagtailsharing.tests.urls'
+ROOT_URLCONF = "wagtailsharing.tests.urls"
 
 DATABASES = {
-    'default': {
-        'ENGINE': os.environ.get(
-            'DATABASE_ENGINE',
-            'django.db.backends.sqlite3'
+    "default": {
+        "ENGINE": os.environ.get(
+            "DATABASE_ENGINE", "django.db.backends.sqlite3"
         ),
-        'NAME': os.environ.get('DATABASE_NAME', 'wagtailsharing.sqlite'),
-        'USER': os.environ.get('DATABASE_USER', None),
-        'PASSWORD': os.environ.get('DATABASE_PASS', None),
-        'HOST': os.environ.get('DATABASE_HOST', None),
-
-        'TEST': {
-            'NAME': os.environ.get('DATABASE_NAME', None),
-        },
+        "NAME": os.environ.get("DATABASE_NAME", "wagtailsharing.sqlite"),
+        "USER": os.environ.get("DATABASE_USER", None),
+        "PASSWORD": os.environ.get("DATABASE_PASS", None),
+        "HOST": os.environ.get("DATABASE_HOST", None),
+        "TEST": {"NAME": os.environ.get("DATABASE_NAME", None)},
     },
 }
 
 if wagtail.VERSION >= (2, 0):
     WAGTAIL_APPS = (
-        'wagtail.contrib.forms',
-        'wagtail.contrib.modeladmin',
-        'wagtail.contrib.routable_page',
-        'wagtail.contrib.settings',
-        'wagtail.tests.routablepage',
-        'wagtail.tests.testapp',
-        'wagtail.admin',
-        'wagtail.core',
-        'wagtail.documents',
-        'wagtail.images',
-        'wagtail.sites',
-        'wagtail.users',
+        "wagtail.contrib.forms",
+        "wagtail.contrib.modeladmin",
+        "wagtail.contrib.routable_page",
+        "wagtail.contrib.settings",
+        "wagtail.tests.routablepage",
+        "wagtail.tests.testapp",
+        "wagtail.admin",
+        "wagtail.core",
+        "wagtail.documents",
+        "wagtail.images",
+        "wagtail.sites",
+        "wagtail.users",
     )
 
-    WAGTAIL_MIDDLEWARE = (
-        'wagtail.core.middleware.SiteMiddleware',
-    )
+    WAGTAIL_MIDDLEWARE = ("wagtail.core.middleware.SiteMiddleware",)
 
     WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        'default': {
-            'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea'
-        },
-        'custom': {
-            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
+        "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
+        "custom": {
+            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
         },
     }
 else:
     WAGTAIL_APPS = (
-        'wagtail.contrib.modeladmin',
-        'wagtail.contrib.wagtailroutablepage',
-        'wagtail.contrib.settings',
-        'wagtail.tests.routablepage',
-        'wagtail.tests.testapp',
-        'wagtail.wagtailadmin',
-        'wagtail.wagtailcore',
-        'wagtail.wagtaildocs',
-        'wagtail.wagtailforms',
-        'wagtail.wagtailimages',
-        'wagtail.wagtailsites',
-        'wagtail.wagtailusers',
+        "wagtail.contrib.modeladmin",
+        "wagtail.contrib.wagtailroutablepage",
+        "wagtail.contrib.settings",
+        "wagtail.tests.routablepage",
+        "wagtail.tests.testapp",
+        "wagtail.wagtailadmin",
+        "wagtail.wagtailcore",
+        "wagtail.wagtaildocs",
+        "wagtail.wagtailforms",
+        "wagtail.wagtailimages",
+        "wagtail.wagtailsites",
+        "wagtail.wagtailusers",
     )
 
-    WAGTAIL_MIDDLEWARE = (
-        'wagtail.wagtailcore.middleware.SiteMiddleware',
-    )
+    WAGTAIL_MIDDLEWARE = ("wagtail.wagtailcore.middleware.SiteMiddleware",)
 
     WAGTAILADMIN_RICH_TEXT_EDITORS = {
-        'default': {
-            'WIDGET': 'wagtail.wagtailadmin.rich_text.HalloRichTextArea',
+        "default": {
+            "WIDGET": "wagtail.wagtailadmin.rich_text.HalloRichTextArea",
         },
-        'custom': {
-            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
+        "custom": {
+            "WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"
         },
     }
 
 if django.VERSION >= (1, 10):
     MIDDLEWARE = (
-        'django.middleware.common.CommonMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        "django.middleware.common.CommonMiddleware",
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.middleware.csrf.CsrfViewMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "django.contrib.messages.middleware.MessageMiddleware",
+        "django.middleware.clickjacking.XFrameOptionsMiddleware",
     ) + WAGTAIL_MIDDLEWARE
 else:
     MIDDLEWARE_CLASSES = (
-        'django.middleware.common.CommonMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        "django.middleware.common.CommonMiddleware",
+        "django.contrib.sessions.middleware.SessionMiddleware",
+        "django.middleware.csrf.CsrfViewMiddleware",
+        "django.contrib.auth.middleware.AuthenticationMiddleware",
+        "django.contrib.auth.middleware.SessionAuthenticationMiddleware",
+        "django.contrib.messages.middleware.MessageMiddleware",
+        "django.middleware.clickjacking.XFrameOptionsMiddleware",
     ) + WAGTAIL_MIDDLEWARE
 
 INSTALLED_APPS = (
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.messages',
-    'django.contrib.sessions',
-    'django.contrib.staticfiles',
-    'taggit',
-) + WAGTAIL_APPS + (
-    'wagtailsharing',
+    (
+        "django.contrib.admin",
+        "django.contrib.auth",
+        "django.contrib.contenttypes",
+        "django.contrib.messages",
+        "django.contrib.sessions",
+        "django.contrib.staticfiles",
+        "taggit",
+    )
+    + WAGTAIL_APPS
+    + ("wagtailsharing",)
 )
 
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-                'django.template.context_processors.request',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+                "django.template.context_processors.request",
             ],
-            'debug': True,
+            "debug": True,
         },
     },
 ]
 
-WAGTAIL_SITE_NAME = 'Test Site'
+WAGTAIL_SITE_NAME = "Test Site"

--- a/wagtailsharing/tests/test_checks.py
+++ b/wagtailsharing/tests/test_checks.py
@@ -6,16 +6,15 @@ from wagtailsharing.checks import modeladmin_installed_check
 
 
 class TestModelAdminInstalledCheck(SimpleTestCase):
-    @override_settings(INSTALLED_APPS=[
-        'wagtail.contrib.modeladmin',
-        'wagtailsharing',
-    ])
+    @override_settings(
+        INSTALLED_APPS=["wagtail.contrib.modeladmin", "wagtailsharing"]
+    )
     def test_check_passes_if_modeladmin_installed(self):
         self.assertFalse(modeladmin_installed_check(apps.get_app_configs()))
 
-    @override_settings(INSTALLED_APPS=['wagtailsharing'])
+    @override_settings(INSTALLED_APPS=["wagtailsharing"])
     def test_check_fails_if_modeladmin_not_installed(self):
         errors = modeladmin_installed_check(apps.get_app_configs())
         self.assertEqual(len(errors), 1)
         self.assertIsInstance(errors[0], Error)
-        self.assertEqual(errors[0].id, 'wagtailsharing.E001')
+        self.assertEqual(errors[0].id, "wagtailsharing.E001")

--- a/wagtailsharing/tests/test_helpers.py
+++ b/wagtailsharing/tests/test_helpers.py
@@ -2,17 +2,16 @@ from __future__ import absolute_import, unicode_literals
 
 from django.test import TestCase
 
+from wagtail.tests.testapp.models import SimplePage
+from wagtailsharing.helpers import get_sharing_url
+from wagtailsharing.models import SharingSite
+from wagtailsharing.tests.helpers import create_draft_page
+
+
 try:
     from wagtail.core.models import Site
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.models import Site
-
-from wagtail.tests.testapp.models import SimplePage
-
-
-from wagtailsharing.helpers import get_sharing_url
-from wagtailsharing.models import SharingSite
-from wagtailsharing.tests.helpers import create_draft_page
 
 
 class TestGetSharingUrl(TestCase):
@@ -20,36 +19,33 @@ class TestGetSharingUrl(TestCase):
         self.default_site = Site.objects.get(is_default_site=True)
 
     def create_sharing_site(self, hostname):
-        SharingSite.objects.create(
-            site=self.default_site,
-            hostname=hostname
-        )
+        SharingSite.objects.create(site=self.default_site, hostname=hostname)
 
     def test_unroutable_page_no_sharing_site_returns_none(self):
-        page = SimplePage(title='title', slug='slug', content='content')
+        page = SimplePage(title="title", slug="slug", content="content")
         self.assertIsNone(get_sharing_url(page))
 
     def test_unroutable_page_sharing_site_returns_none(self):
-        self.create_sharing_site(hostname='hostname')
-        page = SimplePage(title='title', slug='slug', content='content')
+        self.create_sharing_site(hostname="hostname")
+        page = SimplePage(title="title", slug="slug", content="content")
         self.assertIsNone(get_sharing_url(page))
 
     def test_draft_page_no_sharing_site_returns_none(self):
-        page = create_draft_page(self.default_site, title='draft')
+        page = create_draft_page(self.default_site, title="draft")
         self.assertIsNone(get_sharing_url(page))
 
     def test_draft_page_sharing_site_returns_url(self):
-        self.create_sharing_site(hostname='hostname')
-        page = create_draft_page(self.default_site, title='draft')
-        self.assertEqual(get_sharing_url(page), 'http://hostname/draft/')
+        self.create_sharing_site(hostname="hostname")
+        page = create_draft_page(self.default_site, title="draft")
+        self.assertEqual(get_sharing_url(page), "http://hostname/draft/")
 
     def test_published_page_no_sharing_site_returns_none(self):
-        page = create_draft_page(self.default_site, title='published')
+        page = create_draft_page(self.default_site, title="published")
         page.save_revision().publish()
         self.assertIsNone(get_sharing_url(page))
 
     def test_published_page_sharing_site_returns_url(self):
-        self.create_sharing_site(hostname='hostname')
-        page = create_draft_page(self.default_site, title='published')
+        self.create_sharing_site(hostname="hostname")
+        page = create_draft_page(self.default_site, title="published")
         page.save_revision().publish()
-        self.assertEqual(get_sharing_url(page), 'http://hostname/published/')
+        self.assertEqual(get_sharing_url(page), "http://hostname/published/")

--- a/wagtailsharing/tests/test_helpers.py
+++ b/wagtailsharing/tests/test_helpers.py
@@ -2,16 +2,11 @@ from __future__ import absolute_import, unicode_literals
 
 from django.test import TestCase
 
+from wagtail.core.models import Site
 from wagtail.tests.testapp.models import SimplePage
 from wagtailsharing.helpers import get_sharing_url
 from wagtailsharing.models import SharingSite
 from wagtailsharing.tests.helpers import create_draft_page
-
-
-try:
-    from wagtail.core.models import Site
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Site
 
 
 class TestGetSharingUrl(TestCase):

--- a/wagtailsharing/tests/test_helpers.py
+++ b/wagtailsharing/tests/test_helpers.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.test import TestCase
 
 from wagtail.core.models import Site

--- a/wagtailsharing/tests/test_models.py
+++ b/wagtailsharing/tests/test_models.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.db import IntegrityError
 from django.test import RequestFactory, TestCase
 

--- a/wagtailsharing/tests/test_models.py
+++ b/wagtailsharing/tests/test_models.py
@@ -3,13 +3,8 @@ from __future__ import absolute_import, unicode_literals
 from django.db import IntegrityError
 from django.test import RequestFactory, TestCase
 
+from wagtail.core.models import Site
 from wagtailsharing.models import SharingSite
-
-
-try:
-    from wagtail.core.models import Site
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Site
 
 
 class TestSharingSite(TestCase):

--- a/wagtailsharing/tests/test_models.py
+++ b/wagtailsharing/tests/test_models.py
@@ -3,12 +3,13 @@ from __future__ import absolute_import, unicode_literals
 from django.db import IntegrityError
 from django.test import RequestFactory, TestCase
 
+from wagtailsharing.models import SharingSite
+
+
 try:
     from wagtail.core.models import Site
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.models import Site
-
-from wagtailsharing.models import SharingSite
 
 
 class TestSharingSite(TestCase):
@@ -20,72 +21,72 @@ class TestSharingSite(TestCase):
         return SharingSite.objects.create(site=self.default_site, **kwargs)
 
     def test_can_create(self):
-        self.create(hostname='hostname', port=8000)
+        self.create(hostname="hostname", port=8000)
 
     def test_site_related_name_default_empty(self):
         with self.assertRaises(SharingSite.DoesNotExist):
             self.default_site.sharing_site
 
     def test_site_related_name(self):
-        self.create(hostname='hostname', port=8000)
+        self.create(hostname="hostname", port=8000)
         self.assertIsNotNone(self.default_site.sharing_site)
 
     def test_str(self):
-        site = self.create(hostname='hostname', port=8000)
-        self.assertEqual(str(site), 'hostname:8000')
+        site = self.create(hostname="hostname", port=8000)
+        self.assertEqual(str(site), "hostname:8000")
 
     def test_str_no_port(self):
-        site = self.create(hostname='hostname')
-        self.assertEqual(str(site), 'hostname')
+        site = self.create(hostname="hostname")
+        self.assertEqual(str(site), "hostname")
 
     def test_uniqueness(self):
-        self.create(hostname='hostname', port=1234)
+        self.create(hostname="hostname", port=1234)
         with self.assertRaises(IntegrityError):
-            self.create(hostname='hostname', port=1234)
+            self.create(hostname="hostname", port=1234)
 
     def test_multiple_sharing_sites_not_allowed(self):
-        self.create(hostname='hostname', port=1234)
+        self.create(hostname="hostname", port=1234)
         with self.assertRaises(IntegrityError):
-            self.create(hostname='otherhost', port=5678)
+            self.create(hostname="otherhost", port=5678)
 
     def test_find_for_request(self):
-        sharing_site = self.create(hostname='hostname', port=1234)
-        request = self.factory.get('/', HTTP_HOST='hostname', SERVER_PORT=1234)
+        sharing_site = self.create(hostname="hostname", port=1234)
+        request = self.factory.get("/", HTTP_HOST="hostname", SERVER_PORT=1234)
         self.assertEqual(SharingSite.find_for_request(request), sharing_site)
 
     def test_find_for_request_no_sites(self):
-        request = self.factory.get('/', HTTP_HOST='hostname', SERVER_PORT=1234)
+        request = self.factory.get("/", HTTP_HOST="hostname", SERVER_PORT=1234)
         with self.assertRaises(SharingSite.DoesNotExist):
             SharingSite.find_for_request(request)
 
     def test_find_for_request_wrong_port(self):
-        self.create(hostname='hostname', port=1234)
-        request = self.factory.get('/', HTTP_HOST='hostname', SERVER_PORT=5678)
+        self.create(hostname="hostname", port=1234)
+        request = self.factory.get("/", HTTP_HOST="hostname", SERVER_PORT=5678)
         with self.assertRaises(SharingSite.DoesNotExist):
             SharingSite.find_for_request(request)
 
     def test_find_for_request_hostname_keyerror(self):
-        request = self.factory.get('/', SERVER_PORT=5678)
-        del request.META['SERVER_NAME']
+        request = self.factory.get("/", SERVER_PORT=5678)
+        del request.META["SERVER_NAME"]
 
         with self.assertRaises(SharingSite.DoesNotExist):
             SharingSite.find_for_request(request)
 
     def test_find_for_request_no_server_port(self):
-        request = self.factory.get('/')
-        del request.META['SERVER_PORT']
+        request = self.factory.get("/")
+        del request.META["SERVER_PORT"]
 
         with self.assertRaises(SharingSite.DoesNotExist):
             SharingSite.find_for_request(request)
 
     def test_root_url_port_80_http_no_port(self):
-        site = SharingSite(hostname='test.hostname', port=80)
-        self.assertEqual(site.root_url, 'http://test.hostname')
+        site = SharingSite(hostname="test.hostname", port=80)
+        self.assertEqual(site.root_url, "http://test.hostname")
 
     def test_root_url_port_443_https(self):
-        site = SharingSite(hostname='test.hostname', port=443)
-        self.assertEqual(site.root_url, 'https://test.hostname')
+        site = SharingSite(hostname="test.hostname", port=443)
+        self.assertEqual(site.root_url, "https://test.hostname")
 
     def test_root_url_other_port_http(self):
-        site = SharingSite(hostname='test.hostname', port=1234)
-        self.assertEqual(site.root_url, 'http://test.hostname:1234')
+        site = SharingSite(hostname="test.hostname", port=1234)
+        self.assertEqual(site.root_url, "http://test.hostname:1234")

--- a/wagtailsharing/tests/test_urls.py
+++ b/wagtailsharing/tests/test_urls.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.conf.urls import url
 from django.test import TestCase
 
+import wagtail.core.urls as wagtail_core_urls
 import wagtailsharing.urls
 from mock import patch
 
@@ -11,11 +12,6 @@ try:
     from importlib import reload
 except ImportError:
     pass
-
-try:
-    import wagtail.core.urls as wagtail_core_urls
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    import wagtail.wagtailcore.urls as wagtail_core_urls
 
 
 class TestUrlPatterns(TestCase):

--- a/wagtailsharing/tests/test_urls.py
+++ b/wagtailsharing/tests/test_urls.py
@@ -1,20 +1,21 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.conf.urls import url
+from django.test import TestCase
+
+import wagtailsharing.urls
+from mock import patch
+
+
 try:
     from importlib import reload
 except ImportError:
     pass
 
-from django.conf.urls import url
-from django.test import TestCase
-from mock import patch
-
 try:
     import wagtail.core.urls as wagtail_core_urls
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     import wagtail.wagtailcore.urls as wagtail_core_urls
-
-import wagtailsharing.urls
 
 
 class TestUrlPatterns(TestCase):
@@ -23,15 +24,13 @@ class TestUrlPatterns(TestCase):
             pass  # pragma: no cover
 
         root_patterns = [
-            url(r'^foo/$', url, name='foo'),
-            url(r'^((?:[\w\-]+/)*)$', url, name='wagtail_serve'),
-            url(r'^bar/$', url, name='bar'),
+            url(r"^foo/$", url, name="foo"),
+            url(r"^((?:[\w\-]+/)*)$", url, name="wagtail_serve"),
+            url(r"^bar/$", url, name="bar"),
         ]
 
         self.patcher = patch.object(
-            wagtail_core_urls,
-            'urlpatterns',
-            root_patterns
+            wagtail_core_urls, "urlpatterns", root_patterns
         )
         self.patcher.start()
         self.addCleanup(self.patcher.stop)
@@ -40,11 +39,11 @@ class TestUrlPatterns(TestCase):
         self.urlpatterns = wagtailsharing.urls.urlpatterns
 
     def test_leaves_previous_urls_alone(self):
-        self.assertEqual(self.urlpatterns[0].name, 'foo')
+        self.assertEqual(self.urlpatterns[0].name, "foo")
 
     def test_replaces_wagtail_serve(self):
-        self.assertEqual(self.urlpatterns[1].name, 'wagtail_serve')
-        self.assertEqual(self.urlpatterns[1].callback.__name__, 'ServeView')
+        self.assertEqual(self.urlpatterns[1].name, "wagtail_serve")
+        self.assertEqual(self.urlpatterns[1].callback.__name__, "ServeView")
 
     def test_leaves_later_urls_alone(self):
-        self.assertEqual(self.urlpatterns[2].name, 'bar')
+        self.assertEqual(self.urlpatterns[2].name, "bar")

--- a/wagtailsharing/tests/test_urls.py
+++ b/wagtailsharing/tests/test_urls.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from importlib import reload
 
 from django.conf.urls import url
 from django.test import TestCase
@@ -6,12 +6,6 @@ from django.test import TestCase
 import wagtail.core.urls as wagtail_core_urls
 import wagtailsharing.urls
 from mock import patch
-
-
-try:
-    from importlib import reload
-except ImportError:
-    pass
 
 
 class TestUrlPatterns(TestCase):

--- a/wagtailsharing/tests/test_urls.py
+++ b/wagtailsharing/tests/test_urls.py
@@ -1,11 +1,16 @@
 from importlib import reload
 
-from django.conf.urls import url
 from django.test import TestCase
 
 import wagtail.core.urls as wagtail_core_urls
 import wagtailsharing.urls
 from mock import patch
+
+
+try:
+    from django.urls import re_path
+except ImportError:
+    from django.conf.urls import url as re_path
 
 
 class TestUrlPatterns(TestCase):
@@ -14,9 +19,9 @@ class TestUrlPatterns(TestCase):
             pass  # pragma: no cover
 
         root_patterns = [
-            url(r"^foo/$", url, name="foo"),
-            url(r"^((?:[\w\-]+/)*)$", url, name="wagtail_serve"),
-            url(r"^bar/$", url, name="bar"),
+            re_path(r"^foo/$", re_path, name="foo"),
+            re_path(r"^((?:[\w\-]+/)*)$", re_path, name="wagtail_serve"),
+            re_path(r"^bar/$", re_path, name="bar"),
         ]
 
         self.patcher = patch.object(

--- a/wagtailsharing/tests/test_views.py
+++ b/wagtailsharing/tests/test_views.py
@@ -4,6 +4,7 @@ from django.http import Http404, HttpResponse
 from django.test import RequestFactory, TestCase
 
 from mock import patch
+from wagtail.core.models import Site
 from wagtail.tests.utils import WagtailTestUtils
 from wagtailsharing.models import SharingSite
 from wagtailsharing.tests.helpers import (
@@ -11,12 +12,6 @@ from wagtailsharing.tests.helpers import (
     create_draft_routable_page,
 )
 from wagtailsharing.views import ServeView
-
-
-try:
-    from wagtail.core.models import Site
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Site
 
 
 def before_hook_returns_http_response(page, request, args, kwargs):

--- a/wagtailsharing/tests/test_views.py
+++ b/wagtailsharing/tests/test_views.py
@@ -2,36 +2,37 @@ from __future__ import absolute_import, unicode_literals
 
 from django.http import Http404, HttpResponse
 from django.test import RequestFactory, TestCase
+
 from mock import patch
+from wagtail.tests.utils import WagtailTestUtils
+from wagtailsharing.models import SharingSite
+from wagtailsharing.tests.helpers import (
+    create_draft_page,
+    create_draft_routable_page,
+)
+from wagtailsharing.views import ServeView
+
 
 try:
     from wagtail.core.models import Site
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.models import Site
 
-from wagtail.tests.utils import WagtailTestUtils
-
-from wagtailsharing.models import SharingSite
-from wagtailsharing.tests.helpers import (
-    create_draft_page, create_draft_routable_page
-)
-from wagtailsharing.views import ServeView
-
 
 def before_hook_returns_http_response(page, request, args, kwargs):
-    return HttpResponse('returned by hook')
+    return HttpResponse("returned by hook")
 
 
 def before_hook_changes_page_title(page, request, args, kwargs):
-    page.title = 'hook changed title'
+    page.title = "hook changed title"
 
 
 def after_hook_returns_http_response(page, response):
-    return HttpResponse('returned by hook')
+    return HttpResponse("returned by hook")
 
 
 def after_hook_sets_response_header(page, response):
-    response['test-hook-header'] = 'foo'
+    response["test-hook-header"] = "foo"
 
 
 class TestServeView(WagtailTestUtils, TestCase):
@@ -39,185 +40,176 @@ class TestServeView(WagtailTestUtils, TestCase):
         self.factory = RequestFactory()
         self.default_site = Site.objects.get(is_default_site=True)
 
-    def make_request(self, path, method='get', **kwargs):
+    def make_request(self, path, method="get", **kwargs):
         request = getattr(self.factory, method)(path, **kwargs)
         request.site = self.default_site
         return request
 
     def create_sharing_site(self, hostname):
-        SharingSite.objects.create(
-            site=self.default_site,
-            hostname=hostname
-        )
+        SharingSite.objects.create(site=self.default_site, hostname=hostname)
 
     def assert_title_matches(self, response, title):
         self.assertContains(response, title)
 
     def test_no_sharing_site_exists_uses_wagtail_serve(self):
-        request = self.make_request('/')
-        with patch('wagtailsharing.views.wagtail_serve') as wagtail_serve:
+        request = self.make_request("/")
+        with patch("wagtailsharing.views.wagtail_serve") as wagtail_serve:
             ServeView.as_view()(request, request.path)
             wagtail_serve.assert_called_once_with(request, request.path)
 
     def test_no_sharing_site_exists_post_uses_wagtail_serve(self):
-        request = self.make_request('/', method='post')
-        with patch('wagtailsharing.views.wagtail_serve') as wagtail_serve:
+        request = self.make_request("/", method="post")
+        with patch("wagtailsharing.views.wagtail_serve") as wagtail_serve:
             ServeView.as_view()(request, request.path)
             wagtail_serve.assert_called_once_with(request, request.path)
 
     def test_sharing_site_post_uses_wagtail_serve(self):
-        self.create_sharing_site(hostname='hostname')
+        self.create_sharing_site(hostname="hostname")
 
-        request = self.make_request('/', HTTP_HOST='hostname', method='post')
-        with patch('wagtailsharing.views.wagtail_serve') as wagtail_serve:
+        request = self.make_request("/", HTTP_HOST="hostname", method="post")
+        with patch("wagtailsharing.views.wagtail_serve") as wagtail_serve:
             ServeView.as_view()(request, request.path)
             wagtail_serve.assert_called_once_with(request, request.path)
 
     def test_default_site_missing_page_raises_404(self):
-        self.create_sharing_site(hostname='hostname')
+        self.create_sharing_site(hostname="hostname")
 
-        request = self.make_request('/missing/')
+        request = self.make_request("/missing/")
         with self.assertRaises(Http404):
             ServeView.as_view()(request, request.path)
 
     def test_sharing_site_missing_page_raises_404(self):
-        self.create_sharing_site(hostname='hostname')
+        self.create_sharing_site(hostname="hostname")
 
-        request = self.make_request('/missing/', HTTP_HOST='hostname')
+        request = self.make_request("/missing/", HTTP_HOST="hostname")
         with self.assertRaises(Http404):
             ServeView.as_view()(request, request.path)
 
     def test_default_site_unpublished_page_raises_404(self):
-        self.create_sharing_site(hostname='hostname')
-        create_draft_page(self.default_site, title='unpublished')
+        self.create_sharing_site(hostname="hostname")
+        create_draft_page(self.default_site, title="unpublished")
 
-        request = self.make_request('/unpublished/')
+        request = self.make_request("/unpublished/")
         with self.assertRaises(Http404):
             ServeView.as_view()(request, request.path)
 
     def test_sharing_site_unpublished_page_returns_200(self):
-        self.create_sharing_site(hostname='hostname')
-        create_draft_page(self.default_site, title='draft')
+        self.create_sharing_site(hostname="hostname")
+        create_draft_page(self.default_site, title="draft")
 
-        request = self.make_request('/draft/', HTTP_HOST='hostname')
+        request = self.make_request("/draft/", HTTP_HOST="hostname")
         response = ServeView.as_view()(request, request.path)
         self.assertEqual(response.status_code, 200)
 
     def test_default_site_published_page_returns_200(self):
-        self.create_sharing_site(hostname='hostname')
-        page = create_draft_page(self.default_site, title='published')
+        self.create_sharing_site(hostname="hostname")
+        page = create_draft_page(self.default_site, title="published")
         page.save_revision().publish()
 
-        request = self.make_request('/published/')
+        request = self.make_request("/published/")
         response = ServeView.as_view()(request, request.path)
         self.assertEqual(response.status_code, 200)
 
     def test_sharing_site_published_page_returns_200(self):
-        self.create_sharing_site(hostname='hostname')
-        page = create_draft_page(self.default_site, title='published')
+        self.create_sharing_site(hostname="hostname")
+        page = create_draft_page(self.default_site, title="published")
         page.save_revision().publish()
 
-        request = self.make_request('/published/', HTTP_HOST='hostname')
+        request = self.make_request("/published/", HTTP_HOST="hostname")
         response = ServeView.as_view()(request, request.path)
         self.assertEqual(response.status_code, 200)
 
     def test_default_site_draft_version_returns_published_version(self):
-        self.create_sharing_site(hostname='hostname')
-        page = create_draft_page(self.default_site, title='original')
+        self.create_sharing_site(hostname="hostname")
+        page = create_draft_page(self.default_site, title="original")
         page.save_revision().publish()
-        page.title = 'changed'
+        page.title = "changed"
         page.save_revision()
 
-        request = self.make_request('/original/')
+        request = self.make_request("/original/")
         response = ServeView.as_view()(request, request.path)
-        self.assert_title_matches(response, 'original')
+        self.assert_title_matches(response, "original")
 
     def test_sharing_site_draft_version_returns_draft_version(self):
-        self.create_sharing_site(hostname='hostname')
-        page = create_draft_page(self.default_site, title='original')
+        self.create_sharing_site(hostname="hostname")
+        page = create_draft_page(self.default_site, title="original")
         page.save_revision().publish()
-        page.title = 'changed'
+        page.title = "changed"
         page.save_revision()
 
-        request = self.make_request('/original/', HTTP_HOST='hostname')
+        request = self.make_request("/original/", HTTP_HOST="hostname")
         response = ServeView.as_view()(request, request.path)
-        self.assert_title_matches(response, 'changed')
+        self.assert_title_matches(response, "changed")
 
     def test_before_serve_page_hook_called(self):
-        self.create_sharing_site(hostname='hostname')
-        create_draft_page(self.default_site, title='page')
+        self.create_sharing_site(hostname="hostname")
+        create_draft_page(self.default_site, title="page")
 
         with self.register_hook(
-            'before_serve_page',
-            before_hook_returns_http_response
+            "before_serve_page", before_hook_returns_http_response
         ):
-            request = self.make_request('/page/', HTTP_HOST='hostname')
+            request = self.make_request("/page/", HTTP_HOST="hostname")
             response = ServeView.as_view()(request, request.path)
-            self.assertContains(response, 'returned by hook')
+            self.assertContains(response, "returned by hook")
 
     def test_before_serve_shared_page_hook_called(self):
-        self.create_sharing_site(hostname='hostname')
-        create_draft_page(self.default_site, title='page')
+        self.create_sharing_site(hostname="hostname")
+        create_draft_page(self.default_site, title="page")
 
         with self.register_hook(
-            'before_serve_shared_page',
-            before_hook_changes_page_title
+            "before_serve_shared_page", before_hook_changes_page_title
         ):
-            request = self.make_request('/page/', HTTP_HOST='hostname')
+            request = self.make_request("/page/", HTTP_HOST="hostname")
             response = ServeView.as_view()(request, request.path)
-            self.assertContains(response, 'hook changed title')
+            self.assertContains(response, "hook changed title")
 
     def test_before_serve_shared_page_hook_returns_http_response(self):
-        self.create_sharing_site(hostname='hostname')
-        create_draft_page(self.default_site, title='page')
+        self.create_sharing_site(hostname="hostname")
+        create_draft_page(self.default_site, title="page")
 
         with self.register_hook(
-            'before_serve_shared_page',
-            before_hook_returns_http_response
+            "before_serve_shared_page", before_hook_returns_http_response
         ):
-            request = self.make_request('/page/', HTTP_HOST='hostname')
+            request = self.make_request("/page/", HTTP_HOST="hostname")
             response = ServeView.as_view()(request, request.path)
-            self.assertContains(response, 'returned by hook')
+            self.assertContains(response, "returned by hook")
 
     def test_after_serve_shared_page_hook_called(self):
-        self.create_sharing_site(hostname='hostname')
-        create_draft_page(self.default_site, title='page')
+        self.create_sharing_site(hostname="hostname")
+        create_draft_page(self.default_site, title="page")
 
         with self.register_hook(
-            'after_serve_shared_page',
-            after_hook_sets_response_header
+            "after_serve_shared_page", after_hook_sets_response_header
         ):
-            request = self.make_request('/page/', HTTP_HOST='hostname')
+            request = self.make_request("/page/", HTTP_HOST="hostname")
             response = ServeView.as_view()(request, request.path)
-            self.assertEqual(response['test-hook-header'], 'foo')
+            self.assertEqual(response["test-hook-header"], "foo")
 
     def test_after_serve_shared_page_hook_returns_http_response(self):
-        self.create_sharing_site(hostname='hostname')
-        create_draft_page(self.default_site, title='page')
+        self.create_sharing_site(hostname="hostname")
+        create_draft_page(self.default_site, title="page")
 
         with self.register_hook(
-            'after_serve_shared_page',
-            after_hook_returns_http_response
+            "after_serve_shared_page", after_hook_returns_http_response
         ):
-            request = self.make_request('/page/', HTTP_HOST='hostname')
+            request = self.make_request("/page/", HTTP_HOST="hostname")
             response = ServeView.as_view()(request, request.path)
-            self.assertContains(response, 'returned by hook')
+            self.assertContains(response, "returned by hook")
 
     def test_routable_page_index_route(self):
-        self.create_sharing_site(hostname='hostname')
-        create_draft_routable_page(self.default_site, title='routable')
+        self.create_sharing_site(hostname="hostname")
+        create_draft_routable_page(self.default_site, title="routable")
 
-        request = self.make_request('/routable/', HTTP_HOST='hostname')
+        request = self.make_request("/routable/", HTTP_HOST="hostname")
         response = ServeView.as_view()(request, request.path)
         self.assertEqual(response.status_code, 200)
 
     def test_routable_page_sub_route(self):
-        self.create_sharing_site(hostname='hostname')
-        create_draft_routable_page(self.default_site, title='routable')
+        self.create_sharing_site(hostname="hostname")
+        create_draft_routable_page(self.default_site, title="routable")
 
         request = self.make_request(
-            '/routable/archive/year/2000/',
-            HTTP_HOST='hostname'
+            "/routable/archive/year/2000/", HTTP_HOST="hostname"
         )
         response = ServeView.as_view()(request, request.path)
-        self.assertContains(response, 'ARCHIVE BY YEAR: 2000')
+        self.assertContains(response, "ARCHIVE BY YEAR: 2000")

--- a/wagtailsharing/tests/test_views.py
+++ b/wagtailsharing/tests/test_views.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.http import Http404, HttpResponse
 from django.test import RequestFactory, TestCase
 

--- a/wagtailsharing/tests/test_wagtail_hooks.py
+++ b/wagtailsharing/tests/test_wagtail_hooks.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.conf import settings
 from django.http import HttpResponse
 from django.test import TestCase, override_settings

--- a/wagtailsharing/tests/test_wagtail_hooks.py
+++ b/wagtailsharing/tests/test_wagtail_hooks.py
@@ -3,43 +3,40 @@ from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 from django.http import HttpResponse
 from django.test import TestCase, override_settings
+
 from mock import Mock, patch
 from wagtail.tests.testapp.models import SimplePage
-
 from wagtailsharing.wagtail_hooks import add_sharing_banner, add_sharing_link
 
 
 class TestAddSharingLink(TestCase):
     def setUp(self):
-        self.page = SimplePage(title='title', slug='slug', content='content')
+        self.page = SimplePage(title="title", slug="slug", content="content")
         self.page_perms = Mock()
 
     def test_no_link_no_button(self):
         with patch(
-            'wagtailsharing.wagtail_hooks.get_sharing_url',
-            return_value=None
+            "wagtailsharing.wagtail_hooks.get_sharing_url", return_value=None
         ):
             links = add_sharing_link(self.page, self.page_perms)
             self.assertFalse(list(links))
 
     def test_link_makes_button(self):
-        url = 'http://test.domain/slug/'
+        url = "http://test.domain/slug/"
         with patch(
-            'wagtailsharing.wagtail_hooks.get_sharing_url',
-            return_value=url
+            "wagtailsharing.wagtail_hooks.get_sharing_url", return_value=url
         ):
             links = add_sharing_link(self.page, self.page_perms)
             button = next(links)
             self.assertEqual(button.url, url)
             self.assertIn(
-                self.page.get_admin_display_title(),
-                button.attrs['title']
+                self.page.get_admin_display_title(), button.attrs["title"]
             )
 
 
 class TestAddSharingBanner(TestCase):
     def setUp(self):
-        self.page = SimplePage(title='title', slug='slug', content='content')
+        self.page = SimplePage(title="title", slug="slug", content="content")
 
     def add_banner_to_response(self, content):
         response = HttpResponse(content=content)
@@ -48,37 +45,37 @@ class TestAddSharingBanner(TestCase):
 
     @override_settings(WAGTAILSHARING_BANNER=False)
     def test_setting_false_no_banner_added(self):
-        response = self.add_banner_to_response('<body>abcde</body>')
-        self.assertNotContains(response, 'wagtailsharing-banner')
+        response = self.add_banner_to_response("<body>abcde</body>")
+        self.assertNotContains(response, "wagtailsharing-banner")
 
     @override_settings(WAGTAILSHARING_BANNER=True)
     def test_setting_true_banner_is_added(self):
-        response = self.add_banner_to_response('<body>abcde</body>')
-        self.assertContains(response, 'wagtailsharing-banner')
+        response = self.add_banner_to_response("<body>abcde</body>")
+        self.assertContains(response, "wagtailsharing-banner")
 
     @override_settings()
     def test_setting_not_defined_defaults_to_true_banner_is_added(self):
         del settings.WAGTAILSHARING_BANNER
-        response = self.add_banner_to_response('<body>abcde</body>')
-        self.assertContains(response, 'wagtailsharing-banner')
+        response = self.add_banner_to_response("<body>abcde</body>")
+        self.assertContains(response, "wagtailsharing-banner")
 
     def test_no_body_in_response_content_banner_not_added(self):
-        response = self.add_banner_to_response('abcde')
-        self.assertNotContains(response, 'wagtailsharing-banner')
+        response = self.add_banner_to_response("abcde")
+        self.assertNotContains(response, "wagtailsharing-banner")
 
     def test_body_not_first_tag_still_adds_banner(self):
-        content = '<html><body>abcde</body></html>'
+        content = "<html><body>abcde</body></html>"
         response = self.add_banner_to_response(content)
-        self.assertContains(response, 'wagtailsharing-banner')
+        self.assertContains(response, "wagtailsharing-banner")
 
     def test_body_tag_uppercase_still_adds_banner(self):
-        response = self.add_banner_to_response('<BODY>abcde</BODY>')
-        self.assertContains(response, 'wagtailsharing-banner')
+        response = self.add_banner_to_response("<BODY>abcde</BODY>")
+        self.assertContains(response, "wagtailsharing-banner")
 
     def test_body_with_attributes_still_adds_banner(self):
         content = '<body foo="foo" bar="bar">abcde</body>'
         response = self.add_banner_to_response(content)
-        self.assertContains(response, 'wagtailsharing-banner')
+        self.assertContains(response, "wagtailsharing-banner")
 
     def test_banner_leaves_links_alone(self):
         content = '<body>Link <a href="#">and</a> spaces</body>'

--- a/wagtailsharing/tests/urls.py
+++ b/wagtailsharing/tests/urls.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.conf.urls import include, url
 
 from wagtail.admin import urls as wagtailadmin_urls

--- a/wagtailsharing/tests/urls.py
+++ b/wagtailsharing/tests/urls.py
@@ -2,13 +2,8 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import include, url
 
+from wagtail.admin import urls as wagtailadmin_urls
 from wagtailsharing import urls as wagtailsharing_urls
-
-
-try:
-    from wagtail.admin import urls as wagtailadmin_urls
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailadmin import urls as wagtailadmin_urls
 
 
 urlpatterns = [

--- a/wagtailsharing/tests/urls.py
+++ b/wagtailsharing/tests/urls.py
@@ -2,15 +2,16 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import include, url
 
+from wagtailsharing import urls as wagtailsharing_urls
+
+
 try:
     from wagtail.admin import urls as wagtailadmin_urls
 except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailadmin import urls as wagtailadmin_urls
 
-from wagtailsharing import urls as wagtailsharing_urls
-
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'', include(wagtailsharing_urls)),
+    url(r"^admin/", include(wagtailadmin_urls)),
+    url(r"", include(wagtailsharing_urls)),
 ]

--- a/wagtailsharing/tests/urls.py
+++ b/wagtailsharing/tests/urls.py
@@ -1,10 +1,14 @@
-from django.conf.urls import include, url
-
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtailsharing import urls as wagtailsharing_urls
 
 
+try:
+    from django.urls import include, re_path
+except ImportError:
+    from django.conf.urls import include, url as re_path
+
+
 urlpatterns = [
-    url(r"^admin/", include(wagtailadmin_urls)),
-    url(r"", include(wagtailsharing_urls)),
+    re_path(r"^admin/", include(wagtailadmin_urls)),
+    re_path(r"", include(wagtailsharing_urls)),
 ]

--- a/wagtailsharing/urls.py
+++ b/wagtailsharing/urls.py
@@ -1,5 +1,3 @@
-from django.conf.urls import url
-
 from wagtail.core.urls import (
     serve_pattern,
     urlpatterns as wagtailcore_urlpatterns,
@@ -7,8 +5,14 @@ from wagtail.core.urls import (
 from wagtailsharing.views import ServeView
 
 
+try:
+    from django.urls import re_path
+except ImportError:
+    from django.conf.urls import url as re_path
+
+
 urlpatterns = [
-    url(serve_pattern, ServeView.as_view(), name="wagtail_serve")
+    re_path(serve_pattern, ServeView.as_view(), name="wagtail_serve")
     if urlpattern.name == "wagtail_serve"
     else urlpattern
     for urlpattern in wagtailcore_urlpatterns

--- a/wagtailsharing/urls.py
+++ b/wagtailsharing/urls.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.conf.urls import url
 
 from wagtail.core.urls import (

--- a/wagtailsharing/urls.py
+++ b/wagtailsharing/urls.py
@@ -2,19 +2,11 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import url
 
+from wagtail.core.urls import (
+    serve_pattern,
+    urlpatterns as wagtailcore_urlpatterns,
+)
 from wagtailsharing.views import ServeView
-
-
-try:
-    from wagtail.core.urls import (
-        serve_pattern,
-        urlpatterns as wagtailcore_urlpatterns,
-    )
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.urls import (
-        serve_pattern,
-        urlpatterns as wagtailcore_urlpatterns,
-    )
 
 
 urlpatterns = [

--- a/wagtailsharing/urls.py
+++ b/wagtailsharing/urls.py
@@ -2,20 +2,24 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import url
 
-try:
-    from wagtail.core.urls import (
-        serve_pattern, urlpatterns as wagtailcore_urlpatterns
-    )
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailcore.urls import (
-        serve_pattern, urlpatterns as wagtailcore_urlpatterns
-    )
-
 from wagtailsharing.views import ServeView
 
 
+try:
+    from wagtail.core.urls import (
+        serve_pattern,
+        urlpatterns as wagtailcore_urlpatterns,
+    )
+except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
+    from wagtail.wagtailcore.urls import (
+        serve_pattern,
+        urlpatterns as wagtailcore_urlpatterns,
+    )
+
+
 urlpatterns = [
-    url(serve_pattern, ServeView.as_view(), name='wagtail_serve')
-    if urlpattern.name == 'wagtail_serve' else urlpattern
+    url(serve_pattern, ServeView.as_view(), name="wagtail_serve")
+    if urlpattern.name == "wagtail_serve"
+    else urlpattern
     for urlpattern in wagtailcore_urlpatterns
 ]

--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -5,19 +5,11 @@ import inspect
 from django.http import Http404, HttpResponse
 from django.views.generic import View
 
+from wagtail.contrib.routable_page.models import RoutablePageMixin
+from wagtail.core import hooks
+from wagtail.core.url_routing import RouteResult
+from wagtail.core.views import serve as wagtail_serve
 from wagtailsharing.models import SharingSite
-
-
-try:
-    from wagtail.contrib.routable_page.models import RoutablePageMixin
-    from wagtail.core import hooks  # pragma: no cover
-    from wagtail.core.url_routing import RouteResult  # pragma: no cover
-    from wagtail.core.views import serve as wagtail_serve  # pragma: no cover
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin
-    from wagtail.wagtailcore import hooks
-    from wagtail.wagtailcore.url_routing import RouteResult
-    from wagtail.wagtailcore.views import serve as wagtail_serve
 
 
 class ServeView(View):

--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -5,6 +5,9 @@ import inspect
 from django.http import Http404, HttpResponse
 from django.views.generic import View
 
+from wagtailsharing.models import SharingSite
+
+
 try:
     from wagtail.contrib.routable_page.models import RoutablePageMixin
     from wagtail.core import hooks  # pragma: no cover
@@ -16,12 +19,10 @@ except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailcore.url_routing import RouteResult
     from wagtail.wagtailcore.views import serve as wagtail_serve
 
-from wagtailsharing.models import SharingSite
-
 
 class ServeView(View):
     def dispatch(self, request, path):
-        if request.method.upper() != 'GET':
+        if request.method.upper() != "GET":
             return wagtail_serve(request, path)
 
         try:
@@ -51,7 +52,7 @@ class ServeView(View):
         requested page back to the caller despite its draft status.
         """
         path_components = [
-            component for component in path.split('/') if component
+            component for component in path.split("/") if component
         ]
 
         try:
@@ -60,15 +61,15 @@ class ServeView(View):
             exception_source = inspect.trace()[-1]
             stack_frame = exception_source[0]
 
-            page = stack_frame.f_locals['self']
-            path_components = stack_frame.f_locals['path_components']
+            page = stack_frame.f_locals["self"]
+            path_components = stack_frame.f_locals["path_components"]
 
             if isinstance(page, RoutablePageMixin):
                 # This mimics the way that RoutablePageMixin uses the
                 # RouteResult to store the page route view to call.
-                path = '/'
+                path = "/"
                 if path_components:
-                    path += '/'.join(path_components) + '/'
+                    path += "/".join(path_components) + "/"
 
                 view, args, kwargs = page.resolve_subpage(path)
                 return RouteResult(page, args=(view, args, kwargs))
@@ -80,7 +81,7 @@ class ServeView(View):
     @staticmethod
     def serve(page, request, args, kwargs):
         # Call the before_serve_page hook.
-        for fn in hooks.get_hooks('before_serve_page'):
+        for fn in hooks.get_hooks("before_serve_page"):
             result = fn(page, request, args, kwargs)
             if isinstance(result, HttpResponse):
                 return result
@@ -89,7 +90,7 @@ class ServeView(View):
         page = page.get_latest_revision_as_page()
 
         # Call the before_serve_shared_page hook.
-        for fn in hooks.get_hooks('before_serve_shared_page'):
+        for fn in hooks.get_hooks("before_serve_shared_page"):
             result = fn(page, request, args, kwargs)
             if isinstance(result, HttpResponse):
                 return result
@@ -98,7 +99,7 @@ class ServeView(View):
         response = page.serve(request, *args, **kwargs)
 
         # Call the after_serve_shared_page hook.
-        for fn in hooks.get_hooks('after_serve_shared_page'):
+        for fn in hooks.get_hooks("after_serve_shared_page"):
             result = fn(page, response)
             if isinstance(result, HttpResponse):
                 return result

--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import inspect
 
 from django.http import Http404, HttpResponse

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import re
 
 from django.conf import settings

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -7,17 +7,11 @@ from django.template import loader
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from wagtail.admin import widgets as wagtailadmin_widgets
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail.core import hooks
 from wagtailsharing.helpers import get_sharing_url
 from wagtailsharing.models import SharingSite
-
-
-try:
-    from wagtail.admin import widgets as wagtailadmin_widgets
-    from wagtail.core import hooks  # pragma: no cover
-except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
-    from wagtail.wagtailadmin import widgets as wagtailadmin_widgets
-    from wagtail.wagtailcore import hooks
 
 
 class SharingSiteModelAdmin(ModelAdmin):

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -7,6 +7,11 @@ from django.template import loader
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtailsharing.helpers import get_sharing_url
+from wagtailsharing.models import SharingSite
+
+
 try:
     from wagtail.admin import widgets as wagtailadmin_widgets
     from wagtail.core import hooks  # pragma: no cover
@@ -14,55 +19,50 @@ except ImportError:  # pragma: no cover; fallback for Wagtail <2.0
     from wagtail.wagtailadmin import widgets as wagtailadmin_widgets
     from wagtail.wagtailcore import hooks
 
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
-
-from wagtailsharing.helpers import get_sharing_url
-from wagtailsharing.models import SharingSite
-
 
 class SharingSiteModelAdmin(ModelAdmin):
     model = SharingSite
-    menu_icon = 'site'
+    menu_icon = "site"
     menu_order = 603
     add_to_settings_menu = True
-    list_display = ('site', 'hostname', 'port')
+    list_display = ("site", "hostname", "port")
 
 
 modeladmin_register(SharingSiteModelAdmin)
 
 
-@hooks.register('register_page_listing_more_buttons')
+@hooks.register("register_page_listing_more_buttons")
 def add_sharing_link(page, page_perms, is_parent=False):
     sharing_url = get_sharing_url(page)
 
     if sharing_url:
         yield wagtailadmin_widgets.Button(
-            'View sharing link',
+            "View sharing link",
             sharing_url,
             attrs={
-                'title': _("View shared revision of '{}'").format(
+                "title": _("View shared revision of '{}'").format(
                     page.get_admin_display_title()
                 ),
             },
-            priority=90
+            priority=90,
         )
 
 
-@hooks.register('after_serve_shared_page')
+@hooks.register("after_serve_shared_page")
 def add_sharing_banner(page, response):
-    if not getattr(settings, 'WAGTAILSHARING_BANNER', True):
+    if not getattr(settings, "WAGTAILSHARING_BANNER", True):
         return
 
-    if hasattr(response, 'render') and callable(response.render):
+    if hasattr(response, "render") and callable(response.render):
         response.render()
 
     html = force_text(response.content)
-    body = re.search(r'(?i)<body.*?>', html)
+    body = re.search(r"(?i)<body.*?>", html)
 
     if body:
         endpos = body.end()
 
-        banner_template_name = 'wagtailsharing/banner.html'
+        banner_template_name = "wagtailsharing/banner.html"
         banner_template = loader.get_template(banner_template_name)
 
         banner_html = banner_template.render()


### PR DESCRIPTION
## Additions
Support for Django 2.2 imports
Add black to tox

## Removals
Support for Wagtail 1.13 in tox and travis
`from __future__ import absolute_import, unicode_literals`

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests