### PR TITLE
Improve error messages by refactoring ServeView

### DIFF
--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -18,6 +18,9 @@ class ServeView(View):
         try:
             sharing_site = SharingSite.find_for_request(request)
         except SharingSite.DoesNotExist:
+            sharing_site = None
+
+        if not sharing_site:
             return wagtail_serve(request, path)
 
         page, args, kwargs = self.route(sharing_site.site, request, path)


### PR DESCRIPTION
Currently if an exception happens when a page is served, error messages can look like this:

```
Traceback (most recent call last):
sharing_site = SharingSite.find_for_request(request)
...
self.model._meta.object_name
wagtailsharing.models.DoesNotExist: SharingSite matching query does not exist.

During handling of the above exception, another exception occurred:

... (actual exception)
```

In this case, wagtail-sharing has nothing to do with the error, but the stack trace includes it because of the way the ServeView logic works.

This commit alters the logic so that the regular view's errors aren't raised from within wagtail-sharing's exception handline. This should improve error messages by removing mention of SharingSite.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)