### PR TITLE
Remove the Django requirement from this application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,13 @@ matrix:
   include:
     - env: TOXENV=lint
       python: 3.6
-    - env: TOXENV=py36-dj111-wag23
+    - env: TOXENV=py36-wag23
       python: 3.6
-    - env: TOXENV=py36-dj20-wag23
+    - env: TOXENV=py36-wag28
       python: 3.6
-    - env: TOXENV=py36-dj22-wag28
-      python: 3.6
-    - env: TOXENV=py38-dj20-wag23
+    - env: TOXENV=py38-wag23
       python: 3.8
-    - env: TOXENV=py38-dj22-wag28
+    - env: TOXENV=py38-wag28
       python: 3.8
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ matrix:
   include:
     - env: TOXENV=lint
       python: 3.6
-    - env: TOXENV=py36-wag23
+    - env: TOXENV=py36-dj111-wag23
       python: 3.6
-    - env: TOXENV=py36-wag28
+    - env: TOXENV=py36-dj22-wag23
       python: 3.6
-    - env: TOXENV=py38-wag23
-      python: 3.8
-    - env: TOXENV=py38-wag28
+    - env: TOXENV=py36-dj22-wag29
+      python: 3.6
+    - env: TOXENV=py38-dj22-wag29
       python: 3.8
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -163,7 +163,8 @@ Compatibility
 This project has been tested for compatibility with:
 
 * Python 3.6, 3.8
-* Wagtail 2.3, 2.8
+* Django 1.11, 2.2
+* Wagtail 2.3, 2.9
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-sharing/issues/new>`_.

--- a/README.rst
+++ b/README.rst
@@ -163,7 +163,6 @@ Compatibility
 This project has been tested for compatibility with:
 
 * Python 3.6, 3.8
-* Django 1.11, 2.0, 2.2
 * Wagtail 2.3, 2.8
 
 It should be compatible with all intermediate versions, as well.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    "wagtail>=2.3,<2.9",
+    "wagtail>=2.3,<2.10",
 ]
 
 
@@ -11,9 +11,6 @@ testing_extras = [
     "flake8>=2.2.0",
     "mock>=1.0.0",
 ]
-
-
-short_description = "Easier sharing of Wagtail drafts"
 
 
 setup(
@@ -27,11 +24,12 @@ setup(
     packages=find_packages(),
     install_requires=install_requires,
     extras_require={"testing": testing_extras},
-    description=short_description,
+    description="Easier sharing of Wagtail drafts",
     long_description=open("README.rst").read(),
     classifiers=[
         "Framework :: Django",
-        "Framework :: Django :: 3",
+        "Framework :: Django :: 1.11",
+        "Framework :: Django :: 2.2",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 2",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    "Django>=1.11,<2.3",
     "wagtail>=2.3,<2.9",
 ]
 
@@ -23,7 +22,7 @@ setup(
     author="CFPB",
     author_email="tech@cfpb.gov",
     license="CCO",
-    version="2.1",
+    version="2.2",
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,
@@ -32,10 +31,7 @@ setup(
     long_description=open("README.rst").read(),
     classifiers=[
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0",
-        "Framework :: Django :: 2.1",
-        "Framework :: Django :: 2.2",
+        "Framework :: Django :: 3",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 2",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-dj111-wag23,
+    py{36}-dj{111,22}-wag23,
     py{36,38}-dj22-wag29
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-dj{111,22}-wag23,
-    py{36,38}-dj22-wag29
+    py{36}-dj{111,22}-wag{23},
+    py{36,38}-dj{22}-wag{29}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-dj{111,20,22}-wag{23},
-    py{36,38}-dj{22}-wag{28}
+    py{36}-wag23,
+    py{36,38}-wag28
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -18,9 +18,6 @@ basepython=
 
 deps=
     mock>=1.0.0
-    dj111: Django>=1.11,<1.12
-    dj20: Django>=2.0,<2.1
-    dj22: Django>=2.2,<2.3
     wag23: wagtail>=2.3,<2.4
     wag28: wagtail>=2.8,<2.9
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    py{36}-wag23,
-    py{36,38}-wag28
+    py{36}-dj111-wag23,
+    py{36,38}-dj22-wag29
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -18,8 +18,10 @@ basepython=
 
 deps=
     mock>=1.0.0
+    dj111: Django>=1.11,<1.12
+    dj22:  Django>=2.2,<2.3
     wag23: wagtail>=2.3,<2.4
-    wag28: wagtail>=2.8,<2.9
+    wag29: wagtail>=2.9,<2.10
 
 [testenv:lint]
 recreate=False

--- a/wagtailsharing/models.py
+++ b/wagtailsharing/models.py
@@ -1,10 +1,8 @@
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from wagtail.core.models import Site
 
 
-@python_2_unicode_compatible
 class SharingSite(models.Model):
     site = models.OneToOneField(
         Site, on_delete=models.CASCADE, related_name="sharing_site"


### PR DESCRIPTION
We should probably only pin Wagtail in this application, and support
the version range for Django that our Wagtail version specifies.