### PR TITLE
Add a GitHub Action to upload releases to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Publish to PyPI
+on: 
+   release:
+     types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install twine wheel
+    - name: Build the package
+      run: |
+        python setup.py sdist bdist_wheel --universal
+    - name: Upload to PyPI
+      run: twine upload dist/*
+      env: 
+        TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
This commit adds our standard GitHub Action to upload releases to PyPI when the release is created in GitHub. This will remove the separate steps of building a wheel and sdist on the tag and uploading it manually when we create a release.

It will require the `TWINE_USERNAME` and `TWINE_PASSWORD` secrets to be created on this repository with the CFPB PyPI credentials. I am happy to do that.

This particular action is already in use in [Django Flags](https://github.com/cfpb/django-flags/blob/master/.github/workflows/release.yml), [Wagtail Flags](https://github.com/cfpb/wagtail-flags/blob/master/.github/workflows/release.yml), and [Wagtail TreeModelAdmin](https://github.com/cfpb/wagtail-treemodeladmin/blob/master/.github/workflows/release.yml).