### PR TITLE
Add support for latest Wagtail 2.10 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
       python: 3.6
     - env: TOXENV=py38-dj22-wag29
       python: 3.8
+    - env: TOXENV=py36-dj22-wag210
+      python: 3.6
+    - env: TOXENV=py38-dj22-wag210
+      python: 3.8
 
 install:
   pip install tox coveralls

--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,7 @@ This project has been tested for compatibility with:
 
 * Python 3.6, 3.8
 * Django 1.11, 2.2
-* Wagtail 2.3, 2.9
+* Wagtail 2.3, 2.9, 2.10
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-sharing/issues/new>`_.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    "wagtail>=2.3,<2.10",
+    "wagtail>=2.3,<2.11",
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist=True
 envlist=
     lint,
     py{36}-dj{111,22}-wag{23},
-    py{36,38}-dj{22}-wag{29}
+    py{36,38}-dj{22}-wag{29,210}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -22,6 +22,7 @@ deps=
     dj22:  Django>=2.2,<2.3
     wag23: wagtail>=2.3,<2.4
     wag29: wagtail>=2.9,<2.10
+    wag210: wagtail==2.10rc2
 
 [testenv:lint]
 recreate=False

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps=
     dj22:  Django>=2.2,<2.3
     wag23: wagtail>=2.3,<2.4
     wag29: wagtail>=2.9,<2.10
-    wag210: wagtail==2.10rc2
+    wag210: wagtail>=2.10,<2.11
 
 [testenv:lint]
 recreate=False

--- a/wagtailsharing/tests/settings.py
+++ b/wagtailsharing/tests/settings.py
@@ -1,7 +1,5 @@
 import os
 
-import django
-
 
 ALLOWED_HOSTS = ["*"]
 
@@ -38,33 +36,20 @@ WAGTAIL_APPS = (
     "wagtail.users",
 )
 
-WAGTAIL_MIDDLEWARE = ("wagtail.core.middleware.SiteMiddleware",)
-
 WAGTAILADMIN_RICH_TEXT_EDITORS = {
     "default": {"WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea"},
     "custom": {"WIDGET": "wagtail.tests.testapp.rich_text.CustomRichTextArea"},
 }
 
 
-if django.VERSION >= (1, 10):
-    MIDDLEWARE = (
-        "django.middleware.common.CommonMiddleware",
-        "django.contrib.sessions.middleware.SessionMiddleware",
-        "django.middleware.csrf.CsrfViewMiddleware",
-        "django.contrib.auth.middleware.AuthenticationMiddleware",
-        "django.contrib.messages.middleware.MessageMiddleware",
-        "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    ) + WAGTAIL_MIDDLEWARE
-else:
-    MIDDLEWARE_CLASSES = (
-        "django.middleware.common.CommonMiddleware",
-        "django.contrib.sessions.middleware.SessionMiddleware",
-        "django.middleware.csrf.CsrfViewMiddleware",
-        "django.contrib.auth.middleware.AuthenticationMiddleware",
-        "django.contrib.auth.middleware.SessionAuthenticationMiddleware",
-        "django.contrib.messages.middleware.MessageMiddleware",
-        "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    ) + WAGTAIL_MIDDLEWARE
+MIDDLEWARE = (
+    "django.middleware.common.CommonMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+)
 
 INSTALLED_APPS = (
     (

--- a/wagtailsharing/tests/test_views.py
+++ b/wagtailsharing/tests/test_views.py
@@ -1,6 +1,7 @@
 from django.http import Http404, HttpResponse
 from django.test import RequestFactory, TestCase
 
+import wagtail
 from mock import patch
 from wagtail.core.models import Site
 from wagtail.tests.utils import WagtailTestUtils
@@ -36,7 +37,8 @@ class TestServeView(WagtailTestUtils, TestCase):
 
     def make_request(self, path, method="get", **kwargs):
         request = getattr(self.factory, method)(path, **kwargs)
-        request.site = self.default_site
+        if wagtail.VERSION < (2, 9):
+            request.site = self.default_site
         return request
 
     def create_sharing_site(self, hostname):


### PR DESCRIPTION
This task is to pin tox environment on Wagtail 2.10 and ensure all tests pass.

There do not appear to be any upgrade considerations that we should be particularly concerned about with 2.10.


## Additions

- wagtail 2.10 in tox.ini