### PR TITLE
Release version 2.2.1 to support Wagtail 2.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author="CFPB",
     author_email="tech@cfpb.gov",
     license="CCO",
-    version="2.2",
+    version="2.2.1",
     include_package_data=True,
     packages=find_packages(),
     python_requires=">=3.6",


### PR DESCRIPTION
Update version in `setup.py` to provide Wagtail 2.10 support