### PR TITLE
Token urls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,10 @@
 > feature request, you are agreeing to comply with this waiver of copyright interest.
 > Details can be found in our [TERMS](TERMS.md) and [LICENCE](LICENSE).
 
-
 There are two primary ways to help:
- - Using the issue tracker, and
- - Changing the code-base.
 
+- Using the issue tracker, and
+- Changing the code-base.
 
 ## Using the issue tracker
 
@@ -21,7 +20,6 @@ Use the issue tracker to find ways to contribute. Find a bug or a feature, menti
 the issue that you will take on that effort, then follow the _Changing the code-base_
 guidance below.
 
-
 ## Changing the code-base
 
 Generally speaking, you should fork this repository, make changes in your
@@ -30,7 +28,6 @@ tests that validate implemented features and the presence or lack of defects.
 Additionally, the code should follow any stylistic and architectural guidelines
 prescribed by the project. In the absence of such guidelines, mimic the styles
 and patterns in the existing code-base.
-
 
 ## Style
 
@@ -42,7 +39,7 @@ You can format code and imports by calling:
 
 ```
 black wagtailsharing
-isort --recursive wagtailsharing
+isort wagtailsharing
 ```
 
 And you can check for style, import order, and other linting by using:

--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,12 @@ To use tokens in place of the page path on the sharing site, add the following s
 
   WAGTAILSHARING_TOKENIZE_URL = True
 
+In some environments such as Heroku, SERVER_PORT set at release time and the real port is fowarded, so the following is needed in settings:
+
+.. code-block:: python
+
+  USE_X_FORWARDED_PORT = True
+
 Hooks
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,12 @@ Shared pages will also have a new dropdown menu option that links to this sharin
 .. image:: https://raw.githubusercontent.com/cfpb/wagtail-sharing/main/docs/images/dropdown.png
     :alt: Dropdown with sharing link
 
+To use tokens in place of the page path on the sharing site, add the following setting:
+
+.. code-block:: python
+
+  WAGTAILSHARING_TOKENIZE_URL = True
+
 Hooks
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Install the package using pip:
 .. code-block:: bash
 
   $ pip install wagtail-sharing
- 
+
 Add ``wagtailsharing`` as an installed app in your Django settings:
 
 .. code-block:: python
@@ -49,7 +49,7 @@ Run migrations to create required database tables:
 .. code-block:: bash
 
   $ manage.py migrate wagtailsharing
- 
+
 Replace use of Wagtail's catch-all URL pattern:
 
 .. code-block:: diff
@@ -66,7 +66,7 @@ Replace use of Wagtail's catch-all URL pattern:
 Sharing sites
 -------------
 
-The Wagtail admin now contains a new section under Settings called Sharing Sites that allows users to define how they would like to expose latest page revisions. 
+The Wagtail admin now contains a new section under Settings called Sharing Sites that allows users to define how they would like to expose latest page revisions.
 
 .. image:: https://raw.githubusercontent.com/cfpb/wagtail-sharing/main/docs/images/sharing-sites.png
     :width: 200px

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 from setuptools import find_packages, setup
 
+
 install_requires = [
     "wagtail>=2.7,<3",
+    "pyjwt>1.7,<2.0",
 ]
 
 testing_extras = ["coverage>=3.7.0"]

--- a/wagtailsharing/helpers.py
+++ b/wagtailsharing/helpers.py
@@ -2,6 +2,7 @@ from django.conf import settings
 
 import jwt
 from wagtail.core.models import Site
+
 from wagtailsharing.models import SharingSite
 
 

--- a/wagtailsharing/urls.py
+++ b/wagtailsharing/urls.py
@@ -1,9 +1,11 @@
+from django.conf import settings
+from django.conf.urls import url
+
 from wagtail.core.urls import (
     serve_pattern,
     urlpatterns as wagtailcore_urlpatterns,
 )
-
-from wagtailsharing.views import ServeView
+from wagtailsharing.views import ServeView, TokenServeView
 
 
 try:
@@ -12,9 +14,18 @@ except ImportError:
     from django.conf.urls import url as re_path
 
 
-urlpatterns = [
-    re_path(serve_pattern, ServeView.as_view(), name="wagtail_serve")
-    if urlpattern.name == "wagtail_serve"
-    else urlpattern
-    for urlpattern in wagtailcore_urlpatterns
-]
+if getattr(settings, "WAGTAILSHARING_TOKENIZE_URL", True):
+    urlpatterns = [
+        url(
+            r"^share/([\w\.\-\_]+)/$",
+            TokenServeView.as_view(),
+            name="wagtail_serve",
+        ),
+    ]
+else:
+    urlpatterns = [
+        re_path(serve_pattern, ServeView.as_view(), name="wagtail_serve")
+        if urlpattern.name == "wagtail_serve"
+        else urlpattern
+        for urlpattern in wagtailcore_urlpatterns
+    ]

--- a/wagtailsharing/urls.py
+++ b/wagtailsharing/urls.py
@@ -14,10 +14,11 @@ except ImportError:
     from django.conf.urls import url as re_path
 
 
-if getattr(settings, "WAGTAILSHARING_TOKENIZE_URL", True):
-    urlpatterns = [
+if getattr(settings, "WAGTAILSHARING_TOKENIZE_URL", False):
+    share_path = getattr(settings, "WAGTAILSHARING_TOKEN_SHARE_PATH", "share")
+    urlpatterns = wagtailcore_urlpatterns + [
         url(
-            r"^share/([\w\.\-\_]+)/$",
+            rf"^{share_path}/([\w\.\-\_]+)/$",
             TokenServeView.as_view(),
             name="wagtail_serve",
         ),

--- a/wagtailsharing/urls.py
+++ b/wagtailsharing/urls.py
@@ -5,6 +5,7 @@ from wagtail.core.urls import (
     serve_pattern,
     urlpatterns as wagtailcore_urlpatterns,
 )
+
 from wagtailsharing.views import ServeView, TokenServeView
 
 

--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -111,6 +111,9 @@ class ServeView(View):
 
 class TokenServeView(ServeView):
     def dispatch(self, request, path):
+        if request.method.upper() != "GET":
+            return wagtail_serve(request, path)
+
         sharing_site = self.get_sharing_site(request, path)
 
         if not sharing_site:
@@ -122,7 +125,7 @@ class TokenServeView(ServeView):
             decoded_path = data["path"]
         except Exception as e:
             logging.warn(
-                f"Could not decode wagtail path from sharing link: {e}"
+                f"Could not decode Wagtail path from sharing link: {e}"
             )
             return wagtail_serve(request, path)
 

--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -1,13 +1,14 @@
 import inspect
 
+from django.conf import settings
 from django.http import Http404, HttpResponse
 from django.views.generic import View
 
+import jwt
 from wagtail.contrib.routable_page.models import RoutablePageMixin
 from wagtail.core import hooks
 from wagtail.core.url_routing import RouteResult
 from wagtail.core.views import serve as wagtail_serve
-
 from wagtailsharing.models import SharingSite
 
 
@@ -99,3 +100,10 @@ class ServeView(View):
                 return result
 
         return response
+
+
+class TokenServeView(ServeView):
+    def dispatch(self, request, path):
+        from pudb import set_trace
+
+        set_trace()

--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -10,6 +10,7 @@ from wagtail.contrib.routable_page.models import RoutablePageMixin
 from wagtail.core import hooks
 from wagtail.core.url_routing import RouteResult
 from wagtail.core.views import serve as wagtail_serve
+
 from wagtailsharing.models import SharingSite
 
 

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -8,7 +8,6 @@ from django.utils.translation import ugettext_lazy as _
 from wagtail.admin import widgets as wagtailadmin_widgets
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.core import hooks
-
 from wagtailsharing.helpers import get_sharing_url
 from wagtailsharing.models import SharingSite
 

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -8,6 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 from wagtail.admin import widgets as wagtailadmin_widgets
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.core import hooks
+
 from wagtailsharing.helpers import get_sharing_url
 from wagtailsharing.models import SharingSite
 


### PR DESCRIPTION
Uses a token based URL to allow the sharing link to be a publically accessible (unguessable) URL, so that the content can be reviewed by someone outside of organisation/network.


## Additions

- Option to use a token based url to share content rather than the same wagtail path at the sharing site

## Todos

- Add tests for token creation and view

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* ~~Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)~~
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* ~~Placeholder code is flagged~~
* ~~Visually tested in supported browsers and devices~~
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
