### PR TITLE
Swap Travis Badge for Github Action Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-.. image:: https://travis-ci.org/cfpb/wagtail-sharing.svg?branch=main
+.. image:: https://github.com/cfpb/wagtail-sharing/workflows/test/badge.svg?branch=main
   :alt: Build Status
-  :target: https://travis-ci.org/cfpb/wagtail-sharing
+  :target: https://github.com/cfpb/wagtail-sharing/actions?query=branch%3Amain+workflow%3Atest+
 .. image:: https://coveralls.io/repos/github/cfpb/wagtail-sharing/badge.svg?branch=main
   :alt: Coverage Status
   :target: https://coveralls.io/github/cfpb/wagtail-sharing?branch=main


### PR DESCRIPTION
Swaps the Travis CI Build Badge for the Github Actions Badge

## Changes

- Travis Build Badge to Github Actions Badge