### PR TITLE
Add DOTALL flag to sharing banner body-RE

### DIFF
--- a/wagtailsharing/tests/test_wagtail_hooks.py
+++ b/wagtailsharing/tests/test_wagtail_hooks.py
@@ -81,3 +81,11 @@ class TestAddSharingBanner(TestCase):
         content = '<body>Link <a href="#">and</a> spaces</body>'
         response = self.add_banner_to_response(content)
         self.assertContains(response, '<a href="#">and</a>')
+
+    def test_body_has_newlines_still_adds_banner(self):
+        content = """<html><body
+
+        >
+        abcde</body></html>"""
+        response = self.add_banner_to_response(content)
+        self.assertContains(response, "wagtailsharing-banner")

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -50,7 +50,7 @@ def add_sharing_banner(page, response):
         response.render()
 
     html = force_text(response.content)
-    body = re.search(r"(?i)<body.*?>", html)
+    body = re.search(r"(?is)<body.*?>", html)
 
     if body:
         endpos = body.end()


### PR DESCRIPTION
If the HTML `<body>` tag includes newlines before the closing `>`, the sharing banner regular expression would not match it. This fixes that by adding the `re.DOTALL` flag inline.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Passes all existing automated tests
* [x] New functions include new tests
