### PR TITLE
Handle hook signature change in Wagtail 2.10+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Run migrations to create required database tables:
 
 .. code-block:: bash
 
-  $ manage.py migrate wagtailsharing
+  $ python manage.py migrate wagtailsharing
  
 Replace use of Wagtail's catch-all URL pattern:
 

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -25,7 +25,7 @@ modeladmin_register(SharingSiteModelAdmin)
 
 
 @hooks.register("register_page_listing_more_buttons")
-def add_sharing_link(page, page_perms, is_parent=False):
+def add_sharing_link(page, page_perms, is_parent=False, next_url=None):
     sharing_url = get_sharing_url(page)
 
     if sharing_url:


### PR DESCRIPTION
As of version 2.10, certain Wagtail hooks now [accept an optional next_url keyword argument](https://docs.wagtail.io/en/stable/releases/2.10.html#new-next-url-keyword-argument-on-register-page-listing-buttons-and-register-page-listing-more-buttons-hooks). This includes the [`register_page_listing_more_buttons`](https://docs.wagtail.io/en/stable/reference/hooks.html#register-page-listing-more-buttons) hook used in this project.

Users of Wagtail 2.10 and 2.11 currently see this deprecation warning:

> RemovedInWagtail212Warning: register_page_listing_more_buttons hooks will require an additional kwarg `next_url` in a future release. Please update your hook function to accept `next_url`.

This commit fixes that warning while still maintaining compatibility with the older versions of Wagtail.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
