### PR TITLE
Update tests to Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,16 +13,16 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install tox
-  
+
       - name: Run tox -e lint
         run: tox
-        env: 
+        env:
           TOXENV: lint
 
   test:
@@ -34,23 +34,17 @@ jobs:
         toxenv:
             - py36-dj22-wag27
             - py36-dj22-waglatest
-            - py36-dj31-waglatest
-            - py38-dj22-wag27
-            - py38-dj22-waglatest
-            - py38-dj31-waglatest
+            - py39-dj22-waglatest
+            - py39-dj32-waglatest
         include:
           - toxenv: py36-dj22-wag27
             python-version: 3.6
           - toxenv: py36-dj22-waglatest
             python-version: 3.6
-          - toxenv: py36-dj31-waglatest
-            python-version: 3.6
-          - toxenv: py38-dj22-wag27
-            python-version: 3.8
-          - toxenv: py38-dj22-waglatest
-            python-version: 3.8
-          - toxenv: py38-dj31-waglatest
-            python-version: 3.8
+          - toxenv: py39-dj22-waglatest
+            python-version: 3.9
+          - toxenv: py39-dj32-waglatest
+            python-version: 3.9
 
     steps:
       - uses: actions/checkout@v1
@@ -69,7 +63,7 @@ jobs:
         run: |
             tox
             coveralls
-        env: 
+        env:
           TOXENV: ${{ matrix.toxenv }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    py{36,38}-dj{22}-wag{27,latest},
-    py{36,38}-dj{31}-wag{latest}
+    py{36}-dj{22}-wag{27,latest},
+    py{39}-dj{22,32}-wag{latest}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -16,17 +16,17 @@ setenv=
 
 basepython=
     py36: python3.6
-    py38: python3.8
+    py39: python3.9
 
 deps=
     mock>=1.0.0
     dj22:  Django>=2.2,<2.3
-    dj31:  Django>=3.1,<3.2
+    dj32:  Django>=3.2,<3.3
     wag27: wagtail>=2.7,<2.8
     waglatest: wagtail<3
 
 [testenv:lint]
-basepython=python3.8
+basepython=python3.9
 deps=
     black
     flake8
@@ -37,7 +37,7 @@ commands=
     isort --check-only --diff wagtailsharing
 
 [flake8]
-ignore=E731,W503,W504
+ignore=E732,W503,W504
 exclude=
     .git,
     .tox,


### PR DESCRIPTION
This change updates our tests to run against Python 3.9.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
