### PR TITLE
Remove Coveralls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,13 +60,45 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox coveralls
+          pip install tox
 
       - name: Run tox
         run: |
             tox
-            coveralls
         env:
           TOXENV: ${{ matrix.toxenv }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Store test coverage
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: .coverage.*
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    needs:
+      - test
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Retrieve test coverage
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage
+
+      - name: Check coverage
+        run: tox -e coverage
+

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
 .. image:: https://github.com/cfpb/wagtail-sharing/workflows/test/badge.svg?branch=main
   :alt: Build Status
   :target: https://github.com/cfpb/wagtail-sharing/actions?query=branch%3Amain+workflow%3Atest+
-.. image:: https://coveralls.io/repos/github/cfpb/wagtail-sharing/badge.svg?branch=main
-  :alt: Coverage Status
-  :target: https://coveralls.io/github/cfpb/wagtail-sharing?branch=main
 
 wagtail-sharing
 ===============

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,13 @@ envlist=
     lint,
     py{36}-dj{22}-wag{27,latest},
     py{39}-dj{22,32,40}-wag{latest}
+    coverage
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=
     coverage erase
-    coverage run -m django test {posargs}
-    coverage report -m
+    coverage run --parallel-mode -m django test {posargs}
 setenv=
     DJANGO_SETTINGS_MODULE=wagtailsharing.tests.settings
 
@@ -36,6 +36,16 @@ commands=
     black --check wagtailsharing setup.py
     flake8 wagtailsharing setup.py
     isort --check-only --diff wagtailsharing
+
+[testenv:coverage]
+basepython=python3.9
+deps=
+    coverage
+    diff_cover
+commands=
+    coverage combine
+    coverage xml
+    diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
 [flake8]
 ignore=E732,W503,W504


### PR DESCRIPTION
This change removes Coveralls in favor of using [diff-cover](https://pypi.org/project/diff-cover/) in GitHub Actions.

This is how we’re doing code coverage in [consumerfinance.gov](https://github.com/cfpb/consumerfinance.gov), [django-flags](https://github.com/cfpb/django-flags), and [wagtail-flags](https://github.com/cfpb/wagtail-flags).

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)