### PR TITLE
Remove definition of default_app_config

### DIFF
--- a/wagtailsharing/__init__.py
+++ b/wagtailsharing/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "wagtailsharing.apps.WagtailSharingAppConfig"


### PR DESCRIPTION
Django 3.2 removed the need to define a `default_app_config` in an app's \_\_init__.py file:

https://docs.djangoproject.com/en/4.1/releases/3.2/#automatic-appconfig-discovery

This is deprecated as of 3.2 and defining it triggers this warning:

> RemovedInDjango41Warning: 'wagtailsharing' defines default_app_config = 'wagtailsharing.apps.WagtailSharingAppConfig'. Django now detects this configuration automatically. You can remove default_app_config.

This commit removes the `default_app_config` definition to remove that deprecation warning.