### PR TITLE
Add Sharing Link button to the page header

### DIFF
--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -24,6 +24,7 @@ class SharingSiteModelAdmin(ModelAdmin):
 modeladmin_register(SharingSiteModelAdmin)
 
 
+@hooks.register("register_page_header_buttons")
 @hooks.register("register_page_listing_more_buttons")
 def add_sharing_link(page, page_perms, is_parent=False, next_url=None):
     sharing_url = get_sharing_url(page)
@@ -32,6 +33,7 @@ def add_sharing_link(page, page_perms, is_parent=False, next_url=None):
         yield wagtailadmin_widgets.Button(
             "View sharing link",
             sharing_url,
+            icon_name="draft",
             attrs={
                 "title": _("View shared revision of '{}'").format(
                     page.get_admin_display_title()


### PR DESCRIPTION
Wagtail 4 has moved the page header buttons into a drop-down menu, allowing more space for new buttons.

This change adds the “View sharing link” for any page to its header buttons menu, which appear on both the page’s listing view of child pages as well as its edit view.

This means that for every page, the “View sharing link” now appears in the “More” context menu in the parent’s listing view, in the header menu in its own listing view, and in the header menu in its edit view.

Short description explaining the high-level reason for the pull request

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Passes all existing automated tests