### PR TITLE
Wagtail 5.1 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,19 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.11']
-        django: ['3.2', '4.1']
-        wagtail: ['4.1', '4.2']
+        django: ['3.2', '4.1', '4.2']
+        wagtail: ['4.1', '4.2', '5.0', '5.1']
         include:
           - python: '3.8'
             django: '3.2'
             wagtail: '3.0'
+        exclude:
+          - django: '4.2'
+            wagtail: '4.1'
+          - django: '4.2'
+            wagtail: '4.2'
+          - python: '3.11'
+            django: '3.2'
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## Unreleased
+
+- Add support for Wagtail 5.1
+
 ## 2.10 - 2023-08-16
 
 - Deprecate reliance on Wagtail's testapp (https://github.com/cfpb/wagtail-sharing/pull/68)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 3",
     "Framework :: Wagtail :: 4",
+    "Framework :: Wagtail :: 5",
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "License :: Public Domain",
     "Programming Language :: Python",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ skipsdist=True
 envlist=
     lint,
     python{3.8}-django{3.2}-wagtail{3.0},
-    python{3.8,3.11}-django{3.2,4.1}-wagtail{4.1,4.2},
+    python{3.11}-django{4.1}-wagtail{4.1,4.2,5.0,5.1},
+    python{3.11}-django{4.2}-wagtail{5.0,5.1},
     coverage
 
 [testenv]
@@ -21,6 +22,8 @@ deps=
     wagtail3.0: wagtail>=3.0,<4.0
     wagtail4.1: wagtail>=4.1,<4.2
     wagtail4.2: wagtail>=4.2,<4.3
+    wagtail5.0: wagtail>=5.0,<5.1
+    wagtail5.1: wagtail>=5.1,<5.2
 
 [testenv:lint]
 basepython=python3.8

--- a/wagtailsharing/checks.py
+++ b/wagtailsharing/checks.py
@@ -1,23 +1,27 @@
 from django.apps import apps
 from django.core.checks import Error, register
 
+from wagtail import VERSION as WAGTAIL_VERSION
 
-@register()
-def modeladmin_installed_check(app_configs, **kwargs):
-    errors = []
 
-    MODELADMIN_APP = "wagtail.contrib.modeladmin"
-    if not apps.is_installed(MODELADMIN_APP):
-        error_hint = "Is '{}' in settings.INSTALLED_APPS?".format(
-            MODELADMIN_APP
-        )
+if WAGTAIL_VERSION <= (5, 0):
 
-        errors.append(
-            Error(
-                "wagtail-sharing requires the Wagtail ModelAdmin app.",
-                hint=error_hint,
-                id="wagtailsharing.E001",
+    @register()
+    def modeladmin_installed_check(app_configs, **kwargs):
+        errors = []
+
+        MODELADMIN_APP = "wagtail.contrib.modeladmin"
+        if not apps.is_installed(MODELADMIN_APP):
+            error_hint = "Is '{}' in settings.INSTALLED_APPS?".format(
+                MODELADMIN_APP
             )
-        )
 
-    return errors
+            errors.append(
+                Error(
+                    "wagtail-sharing requires the Wagtail ModelAdmin app.",
+                    hint=error_hint,
+                    id="wagtailsharing.E001",
+                )
+            )
+
+        return errors

--- a/wagtailsharing/tests/settings.py
+++ b/wagtailsharing/tests/settings.py
@@ -1,5 +1,7 @@
 import os
 
+from wagtail import VERSION as WAGTAIL_VERSION
+
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
@@ -27,7 +29,9 @@ DATABASES = {
 
 WAGTAIL_APPS = (
     "wagtail.contrib.forms",
-    "wagtail.contrib.modeladmin",
+    "wagtail.contrib.modeladmin"
+    if WAGTAIL_VERSION <= (5, 0)
+    else "wagtail.snippets",
     "wagtail.contrib.routable_page",
     "wagtail.contrib.settings",
     "wagtail.test.routablepage",

--- a/wagtailsharing/tests/test_checks.py
+++ b/wagtailsharing/tests/test_checks.py
@@ -2,19 +2,26 @@ from django.apps import apps
 from django.core.checks import Error
 from django.test import SimpleTestCase, override_settings
 
-from wagtailsharing.checks import modeladmin_installed_check
+from wagtail import VERSION as WAGTAIL_VERSION
 
 
-class TestModelAdminInstalledCheck(SimpleTestCase):
-    @override_settings(
-        INSTALLED_APPS=["wagtail.contrib.modeladmin", "wagtailsharing"]
-    )
-    def test_check_passes_if_modeladmin_installed(self):
-        self.assertFalse(modeladmin_installed_check(apps.get_app_configs()))
+if WAGTAIL_VERSION <= (5, 0):
+    from wagtailsharing.checks import modeladmin_installed_check
 
-    @override_settings(INSTALLED_APPS=["wagtailsharing"])
-    def test_check_fails_if_modeladmin_not_installed(self):
-        errors = modeladmin_installed_check(apps.get_app_configs())
-        self.assertEqual(len(errors), 1)
-        self.assertIsInstance(errors[0], Error)
-        self.assertEqual(errors[0].id, "wagtailsharing.E001")
+if WAGTAIL_VERSION <= (5, 0):
+
+    class TestModelAdminInstalledCheck(SimpleTestCase):
+        @override_settings(
+            INSTALLED_APPS=["wagtail.contrib.modeladmin", "wagtailsharing"]
+        )
+        def test_check_passes_if_modeladmin_installed(self):
+            self.assertFalse(
+                modeladmin_installed_check(apps.get_app_configs())
+            )
+
+        @override_settings(INSTALLED_APPS=["wagtailsharing"])
+        def test_check_fails_if_modeladmin_not_installed(self):
+            errors = modeladmin_installed_check(apps.get_app_configs())
+            self.assertEqual(len(errors), 1)
+            self.assertIsInstance(errors[0], Error)
+            self.assertEqual(errors[0].id, "wagtailsharing.E001")

--- a/wagtailsharing/tests/test_checks.py
+++ b/wagtailsharing/tests/test_checks.py
@@ -1,14 +1,12 @@
-from django.apps import apps
-from django.core.checks import Error
-from django.test import SimpleTestCase, override_settings
-
 from wagtail import VERSION as WAGTAIL_VERSION
 
 
 if WAGTAIL_VERSION <= (5, 0):
-    from wagtailsharing.checks import modeladmin_installed_check
+    from django.apps import apps
+    from django.core.checks import Error
+    from django.test import SimpleTestCase, override_settings
 
-if WAGTAIL_VERSION <= (5, 0):
+    from wagtailsharing.checks import modeladmin_installed_check
 
     class TestModelAdminInstalledCheck(SimpleTestCase):
         @override_settings(

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -5,23 +5,44 @@ from django.template import loader
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail import hooks
 from wagtail.admin import widgets as wagtailadmin_widgets
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+
+
+if WAGTAIL_VERSION >= (5, 1):
+    from wagtail.snippets.models import register_snippet
+    from wagtail.snippets.views.snippets import SnippetViewSet
+else:
+    from wagtail.contrib.modeladmin.options import (
+        ModelAdmin,
+        modeladmin_register,
+    )
 
 from wagtailsharing.helpers import get_sharing_url
 from wagtailsharing.models import SharingSite
 
 
-class SharingSiteModelAdmin(ModelAdmin):
-    model = SharingSite
-    menu_icon = "site"
-    menu_order = 603
-    add_to_settings_menu = True
-    list_display = ("site", "hostname", "port")
+if WAGTAIL_VERSION >= (5, 1):
 
+    class SharingSiteViewSet(SnippetViewSet):
+        model = SharingSite
+        icon = "site"
+        menu_order = 603
+        add_to_settings_menu = True
+        list_display = ("site", "hostname", "port")
 
-modeladmin_register(SharingSiteModelAdmin)
+    register_snippet(SharingSiteViewSet)
+else:
+
+    class SharingSiteModelAdmin(ModelAdmin):
+        model = SharingSite
+        menu_icon = "site"
+        menu_order = 603
+        add_to_settings_menu = True
+        list_display = ("site", "hostname", "port")
+
+    modeladmin_register(SharingSiteModelAdmin)
 
 
 @hooks.register("register_page_header_buttons")


### PR DESCRIPTION
This updates the package to include any Wagtail v5.1 changes.

Upgrade docs [v5.0](https://docs.wagtail.org/en/stable/releases/5.0.html#upgrade-considerations) and [v5.1](https://docs.wagtail.org/en/stable/releases/5.1.html#upgrade-considerations-changes-affecting-all-projects)

## Additions

- Conditional usage of Snippets in place of ModelAdmin

## Changes

- Wagtail v5.0 and v5.1 to the test matrix

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
