### PR TITLE
Add support for Wagtail 5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,13 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.11']
-        django: ['3.2', '4.1']
-        wagtail: ['4.1', '4.2']
-        include:
-          - python: '3.8'
+        django: ['3.2', '4.2']
+        wagtail: ['4.1', '5.0']
+        exclude:
+          - django: '4.2'
+            wagtail: '4.1'
+          - python: '3.11'
             django: '3.2'
-            wagtail: '3.0'
 
     steps:
       - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,7 @@ This project has been tested for compatibility with:
 
 * Python 3.9+
 * Django 3.2+
-* Wagtail 3.0+
+* Wagtail 3.0 - 5.0
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-sharing/issues/new>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,11 @@ dependencies = [
 classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4",
+    "Framework :: Django :: 4.2",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 3",
     "Framework :: Wagtail :: 4",
+    "Framework :: Wagtail :: 5",
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "License :: Public Domain",
     "Programming Language :: Python",

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.8}-django{3.2}-wagtail{3.0},
-    python{3.8,3.11}-django{3.2,4.1}-wagtail{4.1,4.2},
+    python{3.8}-django{3.2}-wagtail{3.0,4.1,5.0},
+    python{3.8,3.11}-django{4.2}-wagtail{5.0},
     coverage
 
 [testenv]
@@ -17,10 +17,10 @@ basepython=
 
 deps=
     django3.2: Django>=3.2,<3.3
-    django4.1: Django>=4.1,<4.2
+    django4.2: Django>=4.2,<4.3
     wagtail3.0: wagtail>=3.0,<4.0
     wagtail4.1: wagtail>=4.1,<4.2
-    wagtail4.2: wagtail>=4.2,<4.3
+    wagtail5.0: wagtail>=5.0,<5.1
 
 [testenv:lint]
 basepython=python3.8
@@ -59,7 +59,7 @@ sections=FUTURE,STDLIB,DJANGO,WAGTAIL,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 [testenv:interactive]
 basepython=python3.8
 deps=
-    Django>=3.2,<3.3
+    wagtail>=5.0,<5.1
 
 commands_pre=
     python {toxinidir}/testmanage.py makemigrations


### PR DESCRIPTION
This commit adds explicit support for Wagtail 5.0 (not 5.1 or 5.2 yet) by adding it to tox.ini and the GitHub Actions tests.

Along with this change comes testing against Django 4.2.

In Wagtail 5.1, modeladmin begins to be deprecated in favor of Wagtail snippets:

https://docs.wagtail.org/en/stable/releases/5.1.html#wagtail-contrib-modeladmin-is-deprecated

For this reason, it makes sense to release a 5.0-specific version and then a subsequent 5.1+ version that uses snippets instead of modeladmin, instead of trying to support both approaches simultaneously.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests