### PR TITLE
Fix deprecation warning in Wagtail 5.2

### DIFF
--- a/wagtailsharing/tests/test_wagtail_hooks.py
+++ b/wagtailsharing/tests/test_wagtail_hooks.py
@@ -16,13 +16,13 @@ from wagtailsharing.wagtail_hooks import (
 class TestAddSharingLink(TestCase):
     def setUp(self):
         self.page = TestPage(title="title", slug="slug")
-        self.page_perms = Mock()
+        self.user = Mock()
 
     def test_no_link_no_button(self):
         with patch(
             "wagtailsharing.wagtail_hooks.get_sharing_url", return_value=None
         ):
-            links = add_sharing_link(self.page, self.page_perms)
+            links = add_sharing_link(self.page, self.user)
             self.assertFalse(list(links))
 
     def test_link_makes_button(self):
@@ -30,7 +30,7 @@ class TestAddSharingLink(TestCase):
         with patch(
             "wagtailsharing.wagtail_hooks.get_sharing_url", return_value=url
         ):
-            links = add_sharing_link(self.page, self.page_perms)
+            links = add_sharing_link(self.page, self.user)
             button = next(links)
             self.assertEqual(button.url, url)
             self.assertIn(

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -27,7 +27,7 @@ register_snippet(SharingSiteViewSet)
 
 @hooks.register("register_page_header_buttons")
 @hooks.register("register_page_listing_more_buttons")
-def add_sharing_link(page, page_perms, is_parent=False, next_url=None):
+def add_sharing_link(page, user, next_url=None, **kwargs):
     sharing_url = get_sharing_url(page)
 
     if sharing_url:


### PR DESCRIPTION
Wagtail 5.2 [changes](https://docs.wagtail.org/en/latest/releases/5.2.html#hooks-for-page-listing-and-page-header-buttons-no-longer-accept-a-page-perms-argument) the signature of the `register_page_header_buttons` and `register_page_listing_more_buttons` hooks, causing a deprecation warning. This commit alters the hook function signature to comply with both the old and new hook specifications.

Fixes #72.