### PR TITLE
Support multiple settings-based sharing hosts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,17 @@ but only works for the default Wagtail site.
 With this configuration,
 draft pages will also be viewable at http://sharing.mysite.com:8000/.
 
+Specify multiple hosts as a list or comma-delimited string
+to share the default Wagtail site on multiple domains:
+
+.. code-block:: python
+
+  WAGTAILSHARING_ROUTER = "wagtailsharing.routers.settings.SettingsHostRouter"
+  WAGTAILSHARING_HOST = [
+      "http://sharing.mysite.com:8000",
+      "http://sharing2.mysite.com:8000",
+  ]
+
 Custom routing
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This change modifies the behavior of the `WAGTAILSHARING_HOST` setting, when used with the SettingsHostRouter router. Instead of specifying a single sharing host, it's now possible to specify multiple sharing hosts, either as a list or as a single comma-delimited string.

This supports testing of wagtail-sharing where you may have multiple domains, say, one for internal testing and one that is public-facing.