### PR TITLE
Support Python 3.13, drop support for < 3.10.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
@@ -34,9 +34,25 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.8', '3.11']
-        django: ['3.2', '4.2']
-        wagtail: ['5.1', '5.2']
+        include:
+          - python: '3.10'
+            django: '4.2'
+            wagtail: '6.2'
+          - python: '3.13'
+            django: '4.2'
+            wagtail: '6.2'
+          - python: '3.12'
+            django: '5.1'
+            wagtail: '6.3'
+          - python: '3.13'
+            django: '5.1'
+            wagtail: '6.3'
+          - python: '3.12'
+            django: '5.1'
+            wagtail: '6.4'
+          - python: '3.13'
+            django: '5.1'
+            wagtail: '6.4'
 
     steps:
       - uses: actions/checkout@v3
@@ -77,7 +93,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 25.11.0
     hooks:
     - id: black
       args: ["wagtailsharing", "setup.py", "testmanage.py", "--line-length=79"]
       exclude: migrations
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.12.0
+    rev: v0.14.3
     hooks:
       - id: ruff
         exclude: migrations
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 7.0.0
     hooks:
       - id: isort
         name: isort (python)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## Unreleased
+
+- Add support for Python 3.13, drop support for Python < 3.10
+
 ## 2.14 2025-09-16
 
 - Support multiple settings-based sharing hosts (https://github.com/cfpb/wagtail-sharing/pull/79)

--- a/README.rst
+++ b/README.rst
@@ -286,12 +286,14 @@ Compatibility
 
 This project has been tested for compatibility with:
 
-* Python 3.8+
-* Django 3.2+
-* Wagtail 5.1+ (see past releases for older Wagtail support)
+* Python 3.10+
+* Django 4.2+
+* Wagtail 6.2+
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-sharing/issues/new>`_.
+
+See past releases for older Python/Django/Wagtail support.
 
 Testing
 -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,24 +3,28 @@ name = "wagtail-sharing"
 version = "2.14"
 description = "Easier sharing of Wagtail drafts"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {text = "CC0"}
 authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
 ]
 dependencies = [
-    "wagtail>=5.1",
+    "wagtail>=6.2",
 ]
 classifiers = [
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.1",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 5",
+    "Framework :: Wagtail :: 6",
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "License :: Public Domain",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [project.optional-dependencies]
@@ -44,7 +48,7 @@ inventory = [
 
 [tool.black]
 line-length = 79
-target-version = ["py38"]
+target-version = ["py313"]
 include = '\.pyi?$'
 exclude = '''
 (

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.8,3.11}-django{3.2,4.2}-wagtail{5.1,5.2},
+    python{3.10,3.13}-django4.2-wagtail6.2,
+    python{3.12,3.13}-django5.1-wagtail{6.3,6.4},
     coverage
 
 [testenv]
@@ -11,15 +12,19 @@ commands=
     python -b -m coverage run --parallel-mode --source='wagtailsharing' {toxinidir}/testmanage.py test {posargs}
 
 basepython=
-    python3.8: python3.8
-    python3.11: python3.11
+    python3.10: python3.10
+    python3.12: python3.12
+    python3.13: python3.13
 
 deps=
-    wagtail5.1: wagtail>=5.1,<5.2
-    wagtail5.2: wagtail>=5.2,<5.3
+    django4.2: Django>=4.2,<5.0
+    django5.1: Django>=5.1,<5.2
+    wagtail6.2: wagtail>=6.2,<6.3
+    wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.4: wagtail>=6.4,<6.5
 
 [testenv:lint]
-basepython=python3.8
+basepython=python3.13
 deps=
     black
     ruff
@@ -30,7 +35,7 @@ commands=
     isort --check-only --diff wagtailsharing testmanage.py
 
 [testenv:coverage]
-basepython=python3.8
+basepython=python3.13
 deps=
     coverage[toml]
     diff_cover
@@ -52,9 +57,9 @@ default_section=THIRDPARTY
 sections=FUTURE,STDLIB,DJANGO,WAGTAIL,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 [testenv:interactive]
-basepython=python3.8
+basepython=python3.13
 deps=
-    wagtail>=5.2,<5.3
+    wagtail>=6.2,<6.3
 
 commands_pre=
     python {toxinidir}/testmanage.py makemigrations

--- a/wagtailsharing/helpers.py
+++ b/wagtailsharing/helpers.py
@@ -1,4 +1,3 @@
-from typing import Optional, Tuple
 from urllib.parse import urlparse
 
 from django.http import HttpRequest
@@ -6,7 +5,7 @@ from django.http import HttpRequest
 
 def get_hostname_and_port_from_request(
     request: HttpRequest,
-) -> Tuple[Optional[str], Optional[int]]:
+) -> tuple[str | None, int | None]:
     try:
         hostname = request.get_host().split(":")[0]
     except KeyError:
@@ -24,14 +23,14 @@ def get_hostname_and_port_from_request(
 
 def make_root_url(hostname: str, port: int) -> str:
     if port == 80:
-        return "http://{}".format(hostname)
+        return f"http://{hostname}"
     elif port == 443:
-        return "https://{}".format(hostname)
+        return f"https://{hostname}"
     else:
-        return "http://{}:{:d}".format(hostname, port)
+        return f"http://{hostname}:{port}"
 
 
-def parse_host(host: str) -> Tuple[str, int]:
+def parse_host(host: str) -> tuple[str, int]:
     """Parse a host string and return a hostname and port."""
     if host.startswith(("http://", "https://")):
         parsed = urlparse(host)

--- a/wagtailsharing/wagtail_hooks.py
+++ b/wagtailsharing/wagtail_hooks.py
@@ -22,8 +22,8 @@ def add_sharing_link(page, user, next_url=None, **kwargs):
             sharing_url,
             icon_name="draft",
             attrs={
-                "aria-label": _("View shared revision of '{}'").format(
-                    page.get_admin_display_title()
+                "aria-label": _(
+                    f"View shared revision of '{page.get_admin_display_title()}'"
                 ),
             },
             priority=90,


### PR DESCRIPTION
Changes test matrix to:

python{3.10,3.13}-django4.2-wagtail6.2,
python{3.12,3.13}-django5.1-wagtail{6.3,6.4}