### PR TITLE
Update wagtail-sharing to Wagtail 7.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
-        python-version: 3.12
+        python-version: 3.13
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -34,31 +34,15 @@ jobs:
 
     strategy:
       matrix:
-        include:
-          - python: '3.10'
-            django: '4.2'
-            wagtail: '6.2'
-          - python: '3.13'
-            django: '4.2'
-            wagtail: '6.2'
-          - python: '3.12'
-            django: '5.1'
-            wagtail: '6.3'
-          - python: '3.13'
-            django: '5.1'
-            wagtail: '6.3'
-          - python: '3.12'
-            django: '5.1'
-            wagtail: '6.4'
-          - python: '3.13'
-            django: '5.1'
-            wagtail: '6.4'
+        python: ["3.12", "3.13"]
+        django: ["5.2"]
+        wagtail: ["6.3", "6.4", "7.0"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -73,7 +57,7 @@ jobs:
           TOXENV: python${{ matrix.python }}-django${{ matrix.django }}-wagtail${{ matrix.wagtail }}
 
       - name: Store test coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-py${{ matrix.python }}-dj${{ matrix.django }}-wag${{ matrix.wagtail }}
           path: .coverage.*
@@ -86,12 +70,12 @@ jobs:
       - test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -101,7 +85,7 @@ jobs:
           pip install tox
 
       - name: Retrieve test coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-*
           merge-multiple: true

--- a/README.rst
+++ b/README.rst
@@ -286,9 +286,9 @@ Compatibility
 
 This project has been tested for compatibility with:
 
-* Python 3.10+
-* Django 4.2+
-* Wagtail 6.2+
+* Python 3.12, 3.13
+* Django 5.2 (LTS)
+* Wagtail 6.3 (LTS), 6.4, 7.0
 
 It should be compatible with all intermediate versions, as well.
 If you find that it is not, please `file an issue <https://github.com/cfpb/wagtail-sharing/issues/new>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wagtail-sharing"
-version = "2.15"
+dynamic = ["version"]
 description = "Easier sharing of Wagtail drafts"
 readme = "README.rst"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "wagtail-sharing"
 version = "2.15"
 description = "Easier sharing of Wagtail drafts"
 readme = "README.rst"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = {text = "CC0"}
 authors = [
     {name = "CFPB", email = "tech@cfpb.gov" }
@@ -13,16 +13,14 @@ dependencies = [
 ]
 classifiers = [
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
     "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     "License :: Public Domain",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 skipsdist=True
 envlist=
     lint,
-    python{3.10,3.13}-django4.2-wagtail6.2,
-    python{3.12,3.13}-django5.1-wagtail{6.3,6.4},
+    python{3.12,3.13}-django5.2-wagtail{6.3,6.4,7.0}
     coverage
 
 [testenv]
@@ -12,27 +11,24 @@ commands=
     python -b -m coverage run --parallel-mode --source='wagtailsharing' {toxinidir}/testmanage.py test {posargs}
 
 basepython=
-    python3.10: python3.10
     python3.12: python3.12
     python3.13: python3.13
 
 deps=
-    django4.2: Django>=4.2,<5.0
-    django5.1: Django>=5.1,<5.2
-    wagtail6.2: wagtail>=6.2,<6.3
+    django5.2: Django>=5.2,<5.3
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
+    wagtail7.0: wagtail>=7.0,<7.1
 
 [testenv:lint]
 basepython=python3.13
 deps=
-    black
     ruff
-    isort
+    bandit
 commands=
-    black --check wagtailsharing setup.py testmanage.py
+    ruff format --check
     ruff check wagtailsharing testmanage.py
-    isort --check-only --diff wagtailsharing testmanage.py
+    bandit -c "pyproject.toml" -r wagtailsharing testmanage.py
 
 [testenv:coverage]
 basepython=python3.13
@@ -59,7 +55,8 @@ sections=FUTURE,STDLIB,DJANGO,WAGTAIL,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 [testenv:interactive]
 basepython=python3.13
 deps=
-    wagtail>=6.2,<6.3
+    Django>=5.2,<5.3
+    wagtail>=7.0,<7.1
 
 commands_pre=
     python {toxinidir}/testmanage.py makemigrations

--- a/wagtailsharing/routers/settings.py
+++ b/wagtailsharing/routers/settings.py
@@ -18,9 +18,7 @@ class SettingsHostRouter(RouterBase):
         super().__init__(*args, **kwargs)
 
         if not hasattr(settings, self.SETTING):
-            raise ImproperlyConfigured(
-                f"settings.{self.SETTING} is not defined"
-            )
+            raise ImproperlyConfigured(f"settings.{self.SETTING} is not defined")
 
         hosts = getattr(settings, self.SETTING)
 

--- a/wagtailsharing/tests/routers/test_db.py
+++ b/wagtailsharing/tests/routers/test_db.py
@@ -27,9 +27,7 @@ class DatabaseHostRouterTests(TestCase):
         self.assertEqual(result, (self.default_site, "/test/"))
 
     def test_route_without_sharing_site(self):
-        request = self.factory.get(
-            "/", HTTP_HOST="nonexistent.com", SERVER_PORT=8080
-        )
+        request = self.factory.get("/", HTTP_HOST="nonexistent.com", SERVER_PORT=8080)
         result = self.router.route(request, "/test/")
 
         self.assertEqual(result, (None, "/test/"))

--- a/wagtailsharing/tests/routers/test_settings.py
+++ b/wagtailsharing/tests/routers/test_settings.py
@@ -101,9 +101,7 @@ class MultipleHostsSettingsRouterTests(TestCase):
             [("sharing.example.com", 443), ("sharing2.example.com", 8080)],
         )
 
-    @override_settings(
-        WAGTAILSHARING_HOST="http://foo.com:8000,http://bar.com:8081"
-    )
+    @override_settings(WAGTAILSHARING_HOST="http://foo.com:8000,http://bar.com:8081")
     def test_sharing_hostnames_string(self):
         self.assertEqual(
             SettingsHostRouter().hostnames_and_ports,

--- a/wagtailsharing/tests/settings.py
+++ b/wagtailsharing/tests/settings.py
@@ -8,15 +8,13 @@ DEBUG = True
 
 ALLOWED_HOSTS = ["*"]
 
-SECRET_KEY = "not needed"
+SECRET_KEY = "not needed"  # nosec - Bandit can ignore this password
 
 ROOT_URLCONF = "wagtailsharing.tests.urls"
 
 DATABASES = {
     "default": {
-        "ENGINE": os.environ.get(
-            "DATABASE_ENGINE", "django.db.backends.sqlite3"
-        ),
+        "ENGINE": os.environ.get("DATABASE_ENGINE", "django.db.backends.sqlite3"),
         "NAME": os.environ.get("DATABASE_NAME", "wagtailsharing.sqlite"),
         "USER": os.environ.get("DATABASE_USER", None),
         "PASSWORD": os.environ.get("DATABASE_PASS", None),

--- a/wagtailsharing/tests/test_helpers.py
+++ b/wagtailsharing/tests/test_helpers.py
@@ -18,9 +18,7 @@ class GetHostnameAndPortFromRequestTests(SimpleTestCase):
         )
 
     def test_request_with_port(self):
-        request = self.factory.get(
-            "/", HTTP_HOST="example.com", SERVER_PORT=5678
-        )
+        request = self.factory.get("/", HTTP_HOST="example.com", SERVER_PORT=5678)
         self.assertEqual(
             get_hostname_and_port_from_request(request), ("example.com", 5678)
         )
@@ -28,9 +26,7 @@ class GetHostnameAndPortFromRequestTests(SimpleTestCase):
     def test_request_without_hostname(self):
         request = self.factory.get("/")
         del request.META["SERVER_NAME"]
-        self.assertEqual(
-            get_hostname_and_port_from_request(request), (None, 80)
-        )
+        self.assertEqual(get_hostname_and_port_from_request(request), (None, 80))
 
     def test_request_without_port(self):
         request = self.factory.get("/", HTTP_HOST="example.com")

--- a/wagtailsharing/tests/test_urls.py
+++ b/wagtailsharing/tests/test_urls.py
@@ -20,9 +20,7 @@ class TestUrlPatterns(TestCase):
             re_path(r"^bar/$", re_path, name="bar"),
         ]
 
-        self.patcher = patch.object(
-            wagtail_core_urls, "urlpatterns", root_patterns
-        )
+        self.patcher = patch.object(wagtail_core_urls, "urlpatterns", root_patterns)
         self.patcher.start()
         self.addCleanup(self.patcher.stop)
 
@@ -40,9 +38,7 @@ class TestUrlPatterns(TestCase):
         if DJANGO_VERSION > (4, 0):
             self.assertEqual(self.urlpatterns[1].callback.__name__, "view")
         else:
-            self.assertEqual(
-                self.urlpatterns[1].callback.__name__, "ServeView"
-            )
+            self.assertEqual(self.urlpatterns[1].callback.__name__, "ServeView")
 
     def test_leaves_later_urls_alone(self):
         self.assertEqual(self.urlpatterns[2].name, "bar")

--- a/wagtailsharing/tests/test_views.py
+++ b/wagtailsharing/tests/test_views.py
@@ -138,9 +138,7 @@ class TestServeView(WagtailTestUtils, TestCase):
         self.create_sharing_site(hostname="hostname")
         create_draft_page(self.default_site, title="page")
 
-        with self.register_hook(
-            "before_serve_page", before_hook_returns_http_response
-        ):
+        with self.register_hook("before_serve_page", before_hook_returns_http_response):
             request = self.make_request("/page/", HTTP_HOST="hostname")
             response = ServeView.as_view()(request, request.path)
             self.assertContains(response, "returned by hook")
@@ -211,9 +209,7 @@ class TestServeView(WagtailTestUtils, TestCase):
         self.create_sharing_site(hostname="sharinghostname")
         create_draft_page(self.default_site, title="page")
 
-        with self.register_hook(
-            "before_route_page", before_hook_returns_http_response
-        ):
+        with self.register_hook("before_route_page", before_hook_returns_http_response):
             request = self.make_request("/page/", HTTP_HOST="sharinghostname")
             response = ServeView.as_view()(request, request.path)
             self.assertContains(response, "returned by hook")

--- a/wagtailsharing/tests/test_wagtail_hooks.py
+++ b/wagtailsharing/tests/test_wagtail_hooks.py
@@ -36,9 +36,7 @@ class TestAddSharingLink(TestCase):
         links = add_sharing_link(page, self.user)
         button = next(links)
         self.assertEqual(button.url, "http://sharing.example.com:8080/test/")
-        self.assertIn(
-            page.get_admin_display_title(), button.attrs["aria-label"]
-        )
+        self.assertIn(page.get_admin_display_title(), button.attrs["aria-label"])
 
 
 class TestAddSharingBanner(TestCase):

--- a/wagtailsharing/tests/urls.py
+++ b/wagtailsharing/tests/urls.py
@@ -17,6 +17,4 @@ if settings.DEBUG:
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
     urlpatterns += staticfiles_urlpatterns()
-    urlpatterns += static(
-        settings.MEDIA_URL, document_root=settings.MEDIA_ROOT
-    )
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/wagtailsharing/views.py
+++ b/wagtailsharing/views.py
@@ -48,9 +48,7 @@ class ServeView(View):
         cases, and, if they fall into the latter category, returns the
         requested page back to the caller despite its draft status.
         """
-        path_components = [
-            component for component in path.split("/") if component
-        ]
+        path_components = [component for component in path.split("/") if component]
 
         try:
             return site.root_page.route(request, path_components)


### PR DESCRIPTION
This pull request updates the package to support Wagtail 7, while dropping support for older versions of python and django.

## Changes
- add support for Wagtail 7.0
- remove support for Django <= 5.1
- remove support for python <= 3.11
