### PR TITLE
Add setuptools_scm section to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ testing = [
 requires = ["setuptools>=64", "setuptools_scm[toml]>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+
 [tool.setuptools.package-data]
 inventory = [
     "templates/wagtailsharing/*",


### PR DESCRIPTION
This empty section is required for proper dynamic versioning of releases; see https://pypi.org/project/setuptools-scm/.

We have this in our other projects, for example https://github.com/cfpb/wagtail-inventory/blob/f99ed8eff6c8346784d6b6332a46978485f85621/pyproject.toml#L48.
